### PR TITLE
fix: resolve reinsertion stack by modify allocation

### DIFF
--- a/foyer-common/src/batch.rs
+++ b/foyer-common/src/batch.rs
@@ -1,0 +1,72 @@
+//  Copyright 2023 MrCroxx
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use parking_lot::Mutex;
+use tokio::sync::oneshot;
+
+const DEFAULT_CAPACITY: usize = 16;
+
+pub enum Identity<T> {
+    Leader(oneshot::Receiver<T>),
+    Follower(oneshot::Receiver<T>),
+}
+
+#[derive(Debug)]
+pub struct Item<A, T> {
+    pub arg: A,
+    pub tx: oneshot::Sender<T>,
+}
+
+#[derive(Debug)]
+pub struct Batch<A, T> {
+    queue: Mutex<Vec<Item<A, T>>>,
+}
+
+impl<A, T> Default for Batch<A, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<A, T> Batch<A, T> {
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            queue: Mutex::new(Vec::with_capacity(capacity)),
+        }
+    }
+
+    pub fn push(&self, arg: A) -> Identity<T> {
+        let (tx, rx) = oneshot::channel();
+        let item = Item { arg, tx };
+        let mut queue = self.queue.lock();
+        let is_leader = queue.is_empty();
+        queue.push(item);
+        if is_leader {
+            Identity::Leader(rx)
+        } else {
+            Identity::Follower(rx)
+        }
+    }
+
+    pub fn rotate(&self) -> Vec<Item<A, T>> {
+        let mut queue = self.queue.lock();
+        let mut q = Vec::with_capacity(queue.capacity());
+        std::mem::swap(&mut *queue, &mut q);
+        q
+    }
+}

--- a/foyer-common/src/lib.rs
+++ b/foyer-common/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![feature(trait_alias)]
 
+pub mod batch;
 pub mod bits;
 pub mod code;
 pub mod queue;

--- a/foyer-common/src/queue.rs
+++ b/foyer-common/src/queue.rs
@@ -95,6 +95,10 @@ impl<T: Debug> AsyncQueue<T> {
     pub fn watch(&self) -> watch::Receiver<usize> {
         self.watch_rx.clone()
     }
+
+    pub fn flash(&self) {
+        self.watch_tx.send(self.len()).unwrap();
+    }
 }
 
 #[cfg(test)]

--- a/foyer-storage/src/reclaimer.rs
+++ b/foyer-storage/src/reclaimer.rs
@@ -170,7 +170,10 @@ where
                         tokio::time::sleep(wait).await;
                     }
 
-                    if self.store.insert(key.clone(), value).await? {
+                    let mut writer = self.store.writer(key.clone(), weight);
+                    writer.set_skippable();
+
+                    if writer.finish(value).await? {
                         for (index, reinsertion) in reinsertions.iter().enumerate() {
                             let judge = judges.get(index);
                             reinsertion.on_insert(&key, weight, &metrics, judge);

--- a/foyer-storage/src/region.rs
+++ b/foyer-storage/src/region.rs
@@ -31,6 +31,7 @@ pub type Version = u32;
 pub enum AllocateResult {
     Ok(WriteSlice),
     Full { slice: WriteSlice, remain: usize },
+    None,
 }
 
 impl AllocateResult {
@@ -38,6 +39,7 @@ impl AllocateResult {
         match self {
             AllocateResult::Ok(slice) => slice,
             AllocateResult::Full { .. } => unreachable!(),
+            AllocateResult::None => unreachable!(),
         }
     }
 }

--- a/foyer-storage/src/region_manager.rs
+++ b/foyer-storage/src/region_manager.rs
@@ -62,17 +62,17 @@ where
     EP: EvictionPolicy<Adapter = RegionEpItemAdapter<EL>>,
     EL: Link,
 {
-    inner: Arc<AsyncRwLock<RegionManagerInner>>,
+    inner: AsyncRwLock<RegionManagerInner>,
     rotate_batch: Batch<(), ()>,
 
     /// Buffer pool for dirty buffers.
-    buffers: Arc<AsyncQueue<Vec<u8, D::IoBufferAllocator>>>,
+    buffers: AsyncQueue<Vec<u8, D::IoBufferAllocator>>,
 
     /// Empty regions.
-    clean_regions: Arc<AsyncQueue<RegionId>>,
+    clean_regions: AsyncQueue<RegionId>,
 
     /// Regions with dirty buffer waiting for flushing.
-    dirty_regions: Arc<AsyncQueue<RegionId>>,
+    dirty_regions: AsyncQueue<RegionId>,
 
     regions: Vec<Region<D>>,
     items: Vec<Arc<RegionEpItem<EL>>>,
@@ -93,7 +93,7 @@ where
         eviction_config: EP::Config,
         device: D,
     ) -> Self {
-        let buffers = Arc::new(AsyncQueue::new());
+        let buffers = AsyncQueue::new();
         for _ in 0..buffer_count {
             let len = device.region_size();
             let buffer = device.io_buffer(len, len);
@@ -101,8 +101,8 @@ where
         }
 
         let eviction = EP::new(eviction_config);
-        let clean_regions = Arc::new(AsyncQueue::new());
-        let dirty_regions = Arc::new(AsyncQueue::new());
+        let clean_regions = AsyncQueue::new();
+        let dirty_regions = AsyncQueue::new();
 
         let mut regions = Vec::with_capacity(region_count);
         let mut items = Vec::with_capacity(region_count);
@@ -122,7 +122,7 @@ where
         let inner = RegionManagerInner { current: None };
 
         Self {
-            inner: Arc::new(AsyncRwLock::new(inner)),
+            inner: AsyncRwLock::new(inner),
             rotate_batch: Batch::new(),
             buffers,
             clean_regions,


### PR DESCRIPTION
## What's changed and what's your intention?

Resolve reinsertion stack by modify allocation.

- Add `must_allocate` flag when allocating. If the flag is false, and there is no space in the current allocating region, return none.
- Foreground insert uses `must_allocate` to allocate buffer, background reinsert uses `!must_allocate`.
- Use batch grouping when rotating the region for allocation. Only the first task that tries to rotate will rotate the allocator, others wait for rotation and retry.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have passed `make check` and `make test` in my local envirorment.

## Related issues or PRs (optional)
#89 