### PR TITLE
fix: ignore trivial error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ check:
 	cargo clippy --all-targets
 
 test:
-	cargo test --all
+	RUST_BACKTRACE=1 cargo test --all

--- a/foyer-storage/src/lib.rs
+++ b/foyer-storage/src/lib.rs
@@ -17,6 +17,8 @@
 #![feature(trait_alias)]
 #![feature(get_mut_unchecked)]
 #![feature(let_chains)]
+#![feature(provide_any)]
+#![feature(error_generic_member_access)]
 #![allow(clippy::type_complexity)]
 
 pub mod admission;


### PR DESCRIPTION
## What's changed and what's your intention?

Ignore trivial errors, print log instead.

Ignored:

1. fetch value error
2. weight not equal error

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have passed `make check` and `make test` in my local envirorment.

## Related issues or PRs (optional)
