### PR TITLE
refactor: remove async slice drop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ check:
 	cargo clippy --all-targets
 
 test:
-	RUST_BACKTRACE=1 cargo test --all
-
+	RUST_BACKTRACE=1 cargo nextest run --all
+	RUST_BACKTRACE=1 cargo test --doc
+	
 jaeger:
 	./scripts/jaeger.sh

--- a/foyer-storage/src/flusher.rs
+++ b/foyer-storage/src/flusher.rs
@@ -114,7 +114,7 @@ where
                 .await?;
             offset += len;
         }
-        slice.destroy().await;
+        drop(slice);
 
         tracing::trace!("[flusher] step 2");
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -4,4 +4,4 @@ if [ -z "$(which cargo-binstall)" ]; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
-cargo binstall -y cargo-hakari cargo-sort
+cargo binstall -y cargo-hakari cargo-sort cargo-nextest


### PR DESCRIPTION
## What's changed and what's your intention?

For `ErwLock` is only used to guarantee the order like a barrier. It does not need to cross `.await`. It is replaced with a sync lock in #119 . And async slice drop is no more needed.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have passed `make check` and `make test` in my local envirorment.

## Related issues or PRs (optional)
#119 