### PR TITLE
chore: rename bench arg

### DIFF
--- a/foyer-storage-bench/src/main.rs
+++ b/foyer-storage-bench/src/main.rs
@@ -133,22 +133,22 @@ pub struct Args {
     /// enable rated random admission policy if `rated_random` > 0
     /// (MiB/s)
     #[arg(long, default_value_t = 0)]
-    rated_random_admission: usize,
+    random_insert_rate_limit: usize,
 
     /// enable rated random reinsertion policy if `rated_random` > 0
     /// (MiB/s)
     #[arg(long, default_value_t = 0)]
-    rated_random_reinsertion: usize,
+    random_reinsert_rate_limit: usize,
 
     /// enable rated ticket admission policy if `rated_random` > 0
     /// (MiB/s)
     #[arg(long, default_value_t = 0)]
-    rated_ticket_admission: usize,
+    ticket_insert_rate_limit: usize,
 
     /// enable rated ticket reinsetion policy if `rated_random` > 0
     /// (MiB/s)
     #[arg(long, default_value_t = 0)]
-    rated_ticket_reinsertion: usize,
+    ticket_reinsert_rate_limit: usize,
 
     /// (MiB/s)
     #[arg(long, default_value_t = 0)]
@@ -311,26 +311,26 @@ async fn main() {
 
     let mut admissions: Vec<Arc<dyn AdmissionPolicy<Key = u64, Value = Vec<u8>>>> = vec![];
     let mut reinsertions: Vec<Arc<dyn ReinsertionPolicy<Key = u64, Value = Vec<u8>>>> = vec![];
-    if args.rated_random_admission > 0 {
+    if args.random_insert_rate_limit > 0 {
         let rr = RatedRandomAdmissionPolicy::new(
-            args.rated_random_admission * 1024 * 1024,
+            args.random_insert_rate_limit * 1024 * 1024,
             Duration::from_millis(100),
         );
         admissions.push(Arc::new(rr));
     }
-    if args.rated_random_reinsertion > 0 {
+    if args.random_reinsert_rate_limit > 0 {
         let rr = RatedRandomReinsertionPolicy::new(
-            args.rated_random_reinsertion * 1024 * 1024,
+            args.random_reinsert_rate_limit * 1024 * 1024,
             Duration::from_millis(100),
         );
         reinsertions.push(Arc::new(rr));
     }
-    if args.rated_ticket_admission > 0 {
-        let rt = RatedTicketAdmissionPolicy::new(args.rated_ticket_admission * 1024 * 1024);
+    if args.ticket_insert_rate_limit > 0 {
+        let rt = RatedTicketAdmissionPolicy::new(args.ticket_insert_rate_limit * 1024 * 1024);
         admissions.push(Arc::new(rt));
     }
-    if args.rated_ticket_reinsertion > 0 {
-        let rt = RatedTicketReinsertionPolicy::new(args.rated_ticket_reinsertion * 1024 * 1024);
+    if args.ticket_reinsert_rate_limit > 0 {
+        let rt = RatedTicketReinsertionPolicy::new(args.ticket_reinsert_rate_limit * 1024 * 1024);
         reinsertions.push(Arc::new(rt));
     }
 

--- a/foyer-storage-bench/src/main.rs
+++ b/foyer-storage-bench/src/main.rs
@@ -130,22 +130,22 @@ pub struct Args {
     #[arg(long, default_value_t = 16)]
     recover_concurrency: usize,
 
-    /// enable rated random admission policy if `rated_random` > 0
+    /// enable rated random admission policy if `random_insert_rate_limit` > 0
     /// (MiB/s)
     #[arg(long, default_value_t = 0)]
     random_insert_rate_limit: usize,
 
-    /// enable rated random reinsertion policy if `rated_random` > 0
+    /// enable rated random reinsertion policy if `random_reinsert_rate_limit` > 0
     /// (MiB/s)
     #[arg(long, default_value_t = 0)]
     random_reinsert_rate_limit: usize,
 
-    /// enable rated ticket admission policy if `rated_random` > 0
+    /// enable rated ticket admission policy if `ticket_insert_rate_limit` > 0
     /// (MiB/s)
     #[arg(long, default_value_t = 0)]
     ticket_insert_rate_limit: usize,
 
-    /// enable rated ticket reinsetion policy if `rated_random` > 0
+    /// enable rated ticket reinsetion policy if `ticket_reinsert_rate_limit` > 0
     /// (MiB/s)
     #[arg(long, default_value_t = 0)]
     ticket_reinsert_rate_limit: usize,


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As titled.

Usage:

```
Usage: foyer-storage-bench [OPTIONS] --dir <DIR>

Options:
  -d, --dir <DIR>
          dir for cache data
      --capacity <CAPACITY>
          (MiB) [default: 1024]
  -t, --time <TIME>
          (s) [default: 60]
      --report-interval <REPORT_INTERVAL>
          (s) [default: 2]
      --iostat-dev <IOSTAT_DEV>
          Some filesystem (e.g. btrfs) can span across multiple block devices and it's hard to decide which device to moitor. Use this argument to specify which block device to monitor [default: ]
      --w-rate <W_RATE>
          (MiB) [default: 0]
      --r-rate <R_RATE>
          (MiB) [default: 0]
      --entry-size-min <ENTRY_SIZE_MIN>
          [default: 65536]
      --entry-size-max <ENTRY_SIZE_MAX>
          [default: 65536]
      --lookup-range <LOOKUP_RANGE>
          [default: 10000]
      --region-size <REGION_SIZE>
          (MiB) [default: 64]
      --buffer-pool-size <BUFFER_POOL_SIZE>
          (MiB) [default: 1024]
      --flushers <FLUSHERS>
          [default: 4]
      --reclaimers <RECLAIMERS>
          [default: 4]
      --align <ALIGN>
          [default: 4096]
      --io-size <IO_SIZE>
          [default: 16384]
      --writers <WRITERS>
          [default: 16]
      --readers <READERS>
          [default: 16]
      --recover-concurrency <RECOVER_CONCURRENCY>
          [default: 16]
      --random-insert-rate-limit <RANDOM_INSERT_RATE_LIMIT>
          enable rated random admission policy if `random_insert_rate_limit` > 0 (MiB/s) [default: 0]
      --random-reinsert-rate-limit <RANDOM_REINSERT_RATE_LIMIT>
          enable rated random reinsertion policy if `random_reinsert_rate_limit` > 0 (MiB/s) [default: 0]
      --ticket-insert-rate-limit <TICKET_INSERT_RATE_LIMIT>
          enable rated ticket admission policy if `ticket_insert_rate_limit` > 0 (MiB/s) [default: 0]
      --ticket-reinsert-rate-limit <TICKET_REINSERT_RATE_LIMIT>
          enable rated ticket reinsetion policy if `ticket_reinsert_rate_limit` > 0 (MiB/s) [default: 0]
      --flush-rate-limit <FLUSH_RATE_LIMIT>
          (MiB/s) [default: 0]
      --reclaim-rate-limit <RECLAIM_RATE_LIMIT>
          (MiB/s) [default: 0]
      --allocation-timeout <ALLOCATION_TIMEOUT>
          (ms) [default: 10]
      --clean-region-threshold <CLEAN_REGION_THRESHOLD>
          `0` means equal to reclaimer count [default: 0]
      --allocator-bits <ALLOCATOR_BITS>
          The count of allocators is `2 ^ allocator bits` [default: 0]
      --metrics
          Weigher to enable metrics exporter
  -h, --help
          Print help (see more with '--help')
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have passed `make check` and `make test` or `make all` in my local envirorment.

## Related issues or PRs (optional)
