### PR TITLE
refactor: remove ErwLock usage

### DIFF
--- a/foyer-storage/src/buffer.rs
+++ b/foyer-storage/src/buffer.rs
@@ -218,12 +218,12 @@ mod tests {
 
     use crate::{
         device::fs::{FsDevice, FsDeviceConfig},
-        ring::{RingBuffer, View},
+        ring::{RingBuffer, RingBufferView},
     };
 
     use super::*;
 
-    fn ent(view: View) -> Entry {
+    fn ent(view: RingBufferView) -> Entry {
         Entry {
             key: Arc::new(()),
             view,

--- a/foyer-storage/src/catalog.rs
+++ b/foyer-storage/src/catalog.rs
@@ -63,6 +63,10 @@ impl Item {
     pub fn index(&self) -> &Index {
         &self.index
     }
+
+    pub fn consume(self) -> (Sequence, Index) {
+        (self.sequence, self.index)
+    }
 }
 
 #[derive(Debug)]

--- a/foyer-storage/src/catalog.rs
+++ b/foyer-storage/src/catalog.rs
@@ -24,22 +24,19 @@ use itertools::Itertools;
 use parking_lot::{Mutex, RwLock};
 use twox_hash::XxHash64;
 
-use crate::{device::BufferAllocator, metrics::Metrics, region::RegionId, ring::View};
+use crate::{
+    device::BufferAllocator,
+    metrics::Metrics,
+    region::{RegionId, RegionView},
+    ring::RingBufferView,
+};
 
 pub type Sequence = u64;
 
 #[derive(Debug, Clone)]
 pub enum Index {
-    RingBuffer {
-        view: View,
-    },
-    Region {
-        region: RegionId,
-        offset: u32,
-        len: u32,
-        key_len: u32,
-        value_len: u32,
-    },
+    RingBuffer { view: RingBufferView },
+    Region { view: RegionView },
 }
 
 #[derive(Debug, Clone)]
@@ -108,8 +105,8 @@ where
     pub fn insert(&self, key: Arc<K>, mut item: Item) {
         // TODO(MrCroxx): compare sequence.
 
-        if let Index::Region { region, .. } = item.index {
-            self.regions[region as usize]
+        if let Index::Region { view } = &item.index {
+            self.regions[*view.id() as usize]
                 .lock()
                 .insert(key.clone(), item.sequence);
         };
@@ -134,8 +131,8 @@ where
     pub fn remove(&self, key: &K) -> Option<Item> {
         let shard = self.shard(key);
         let info: Option<Item> = self.items[shard].write().remove(key);
-        if let Some(info) = &info && let Index::Region { region,..} = info.index {
-            self.regions[region as usize].lock().remove(key);
+        if let Some(info) = &info && let Index::Region { view} = &info.index {
+            self.regions[*view.id() as usize].lock().remove(key);
         }
         info
     }

--- a/foyer-storage/src/metrics.rs
+++ b/foyer-storage/src/metrics.rs
@@ -154,7 +154,6 @@ pub struct Metrics {
     pub op_duration_lookup_hit: Histogram,
     pub op_duration_lookup_miss: Histogram,
     pub op_duration_remove: Histogram,
-    pub slow_op_duration_flush: Histogram,
     pub slow_op_duration_reclaim: Histogram,
 
     pub op_bytes_insert: IntCounter,
@@ -193,9 +192,6 @@ impl Metrics {
             .op_duration
             .with_label_values(&[foyer, "lookup", "miss"]);
         let op_duration_remove = global.op_duration.with_label_values(&[foyer, "remove", ""]);
-        let slow_op_duration_flush = global
-            .slow_op_duration
-            .with_label_values(&[foyer, "flush", ""]);
         let slow_op_duration_reclaim = global
             .slow_op_duration
             .with_label_values(&[foyer, "reclaim", ""]);
@@ -244,7 +240,6 @@ impl Metrics {
             op_duration_lookup_hit,
             op_duration_lookup_miss,
             op_duration_remove,
-            slow_op_duration_flush,
             slow_op_duration_reclaim,
 
             op_bytes_insert,

--- a/foyer-storage/src/reclaimer.rs
+++ b/foyer-storage/src/reclaimer.rs
@@ -117,12 +117,7 @@ where
 
         // after drop indices and acquire exclusive lock, no writers or readers are supposed to access the region
         {
-            let guard = region.exclusive(false, false).await;
-            tracing::trace!(
-                "[reclaimer] region {}, physical readers: {}",
-                region.id(),
-                guard.readers(),
-            );
+            let guard = region.exclusive().await;
             drop(guard);
         }
 

--- a/foyer-storage/src/reclaimer.rs
+++ b/foyer-storage/src/reclaimer.rs
@@ -12,7 +12,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{atomic::Ordering, Arc},
+    time::Duration,
+};
 
 use crate::{
     device::Device,
@@ -113,15 +116,18 @@ where
         let region = self.region_manager.region(&region_id);
 
         // step 1: drop indices
-        let _indices = self.store.catalog().take_region(&region_id);
+        let indices = self.store.catalog().take_region(&region_id);
 
         // Must guarantee there is no following reads on the region to be reclaim.
         // Which means there is no unfinished reader or reader who holds index and prepare to read.
 
         // wait unfinished readers
         {
-            let guard = region.exclusive().await;
-            drop(guard);
+            // only each `indices` holds one ref
+            while region.refs().load(Ordering::SeqCst) > indices.len() {
+                println!("refs: {}", region.refs().load(Ordering::SeqCst));
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
         }
 
         // step 2: do reinsertion

--- a/foyer-storage/src/reclaimer.rs
+++ b/foyer-storage/src/reclaimer.rs
@@ -115,7 +115,10 @@ where
         // step 1: drop indices
         let _indices = self.store.catalog().take_region(&region_id);
 
-        // after drop indices and acquire exclusive lock, no writers or readers are supposed to access the region
+        // Must guarantee there is no following reads on the region to be reclaim.
+        // Which means there is no unfinished reader or reader who holds index and prepare to read.
+
+        // wait unfinished readers
         {
             let guard = region.exclusive().await;
             drop(guard);

--- a/foyer-storage/src/region.rs
+++ b/foyer-storage/src/region.rs
@@ -13,15 +13,17 @@
 //  limitations under the License.
 
 use bytes::{Buf, BufMut};
-use parking_lot::{lock_api::ArcMutexGuard, Mutex, MutexGuard, RawMutex};
+use parking_lot::{Mutex, MutexGuard};
 use std::{
     collections::btree_map::{BTreeMap, Entry},
     fmt::Debug,
     ops::RangeBounds,
-    sync::{atomic::AtomicUsize, Arc},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 use tokio::sync::oneshot;
-use tracing::instrument;
 
 use crate::{
     device::{BufferAllocator, Device},
@@ -55,10 +57,8 @@ pub struct RegionInner<A>
 where
     A: BufferAllocator,
 {
-    readers: usize,
-
     #[expect(clippy::type_complexity)]
-    waits: BTreeMap<(usize, usize), Vec<oneshot::Sender<Result<ReadSlice<A>>>>>,
+    waits: BTreeMap<(usize, usize), Vec<oneshot::Sender<Result<Arc<Vec<u8, A>>>>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -89,8 +89,6 @@ where
 {
     pub fn new(id: RegionId, device: D) -> Self {
         let inner = RegionInner {
-            readers: 0,
-
             waits: BTreeMap::new(),
         };
         Self {
@@ -102,6 +100,7 @@ where
     }
 
     pub fn view(&self, offset: u32, len: u32, key_len: u32, value_len: u32) -> RegionView {
+        self.refs.fetch_add(1, Ordering::SeqCst);
         RegionView {
             id: self.id,
             offset,
@@ -110,6 +109,10 @@ where
             value_len,
             refs: Arc::clone(&self.refs),
         }
+    }
+
+    pub fn refs(&self) -> &Arc<AtomicUsize> {
+        &self.refs
     }
 
     /// Load region data into a [`ReadSlice`].
@@ -123,7 +126,7 @@ where
     pub async fn load(
         &self,
         range: impl RangeBounds<usize>,
-    ) -> Result<Option<ReadSlice<D::IoBufferAllocator>>> {
+    ) -> Result<Option<Arc<Vec<u8, D::IoBufferAllocator>>>> {
         let start = match range.start_bound() {
             std::ops::Bound::Included(i) => *i,
             std::ops::Bound::Excluded(i) => *i + 1,
@@ -151,7 +154,6 @@ where
                 }
             };
 
-            inner.readers += 1;
             drop(inner);
 
             rx
@@ -185,57 +187,27 @@ where
                 Err(e) => {
                     let mut inner = self.inner.lock();
                     self.cleanup(&mut inner, start, end)?;
-                    inner.readers -= 1;
                     return Err(e.into());
                 }
             };
             if read != len {
                 let mut inner = self.inner.lock();
                 self.cleanup(&mut inner, start, end)?;
-                inner.readers -= 1;
                 return Ok(None);
             }
             offset += len;
         }
         let buf = Arc::new(buf);
 
-        let cleanup = {
-            let inner = self.inner.clone();
-            let f = move || {
-                let mut guard = inner.lock();
-                guard.readers -= 1;
-            };
-            Box::new(f)
-        };
-
         if let Some(txs) = self.inner.lock().waits.remove(&(start, end)) {
             // TODO: handle error !!!!!!!!!!!
             for tx in txs {
-                tx.send(Ok(ReadSlice {
-                    buf: buf.clone(),
-                    cleanup: Some(cleanup.clone()),
-                }))
-                .map_err(|_| anyhow::anyhow!("fail to send load result"))?;
+                tx.send(Ok(buf.clone()))
+                    .map_err(|_| anyhow::anyhow!("fail to send load result"))?;
             }
         }
 
-        Ok(Some(ReadSlice {
-            buf,
-            cleanup: Some(cleanup),
-        }))
-    }
-
-    #[instrument(skip(self))]
-    pub async fn exclusive(&self) -> ArcMutexGuard<RawMutex, RegionInner<D::IoBufferAllocator>> {
-        loop {
-            {
-                let guard = self.inner.clone().lock_arc();
-                if guard.readers == 0 {
-                    break guard;
-                }
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-        }
+        Ok(Some(buf))
     }
 
     pub fn id(&self) -> RegionId {
@@ -254,7 +226,6 @@ where
         end: usize,
     ) -> Result<()> {
         if let Some(txs) = guard.waits.remove(&(start, end)) {
-            guard.readers -= txs.len();
             for tx in txs {
                 tx.send(Err(anyhow::anyhow!("cancelled by previous error").into()))
                     .map_err(|_| anyhow::anyhow!("fail to cleanup waits"))?;
@@ -264,72 +235,11 @@ where
     }
 }
 
-impl<A> RegionInner<A>
-where
-    A: BufferAllocator,
-{
-    pub fn readers(&self) -> usize {
-        self.readers
-    }
-}
-
 // read & write slice
 
 pub trait CleanupFn = FnOnce() + Send + Sync + 'static;
 
-pub struct ReadSlice<A>
-where
-    A: BufferAllocator,
-{
-    buf: Arc<Vec<u8, A>>,
-    cleanup: Option<Box<dyn CleanupFn>>,
-}
-
-impl<A> Debug for ReadSlice<A>
-where
-    A: BufferAllocator,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReadSlice")
-            .field("len", &self.buf.len())
-            .finish()
-    }
-}
-
-impl<A> ReadSlice<A>
-where
-    A: BufferAllocator,
-{
-    pub fn len(&self) -> usize {
-        self.buf.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
-impl<A> AsRef<[u8]> for ReadSlice<A>
-where
-    A: BufferAllocator,
-{
-    fn as_ref(&self) -> &[u8] {
-        self.buf.as_ref()
-    }
-}
-
-impl<A> Drop for ReadSlice<A>
-where
-    A: BufferAllocator,
-{
-    fn drop(&mut self) {
-        if let Some(f) = self.cleanup.take() {
-            f();
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RegionView {
     id: RegionId,
     offset: u32,
@@ -337,6 +247,26 @@ pub struct RegionView {
     key_len: u32,
     value_len: u32,
     refs: Arc<AtomicUsize>,
+}
+
+impl Clone for RegionView {
+    fn clone(&self) -> Self {
+        self.refs.fetch_add(1, Ordering::SeqCst);
+        Self {
+            id: self.id,
+            offset: self.offset,
+            len: self.len,
+            key_len: self.key_len,
+            value_len: self.value_len,
+            refs: Arc::clone(&self.refs),
+        }
+    }
+}
+
+impl Drop for RegionView {
+    fn drop(&mut self) {
+        self.refs.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 impl RegionView {


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Since there is only 1 counter to wait (readers), there is no need to use `ErwLock` anymore. R.I.P. exclusive-read-write lock.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have passed `make check` and `make test` or `make all` in my local envirorment.

## Related issues or PRs (optional)
#184 
#193 