### PR TITLE
refactor: require Key and Value to impl Clone

### DIFF
--- a/foyer-common/src/code.rs
+++ b/foyer-common/src/code.rs
@@ -102,6 +102,9 @@ pub trait Cursor: Send + Sync + 'static + std::io::Read {
     }
 }
 
+/// [`Key`] is required to implement [`Clone`].
+/// 
+/// If cloning a [`Key`] is expensive, wrap it with [`std::sync::Arc`].
 #[expect(unused_variables)]
 pub trait Key:
     Sized
@@ -113,8 +116,8 @@ pub trait Key:
     + PartialEq
     + Ord
     + PartialOrd
-    + Clone
     + std::fmt::Debug
+    + Clone
 {
     type Cursor: Cursor<T = Self> = UnimplementedCursor<Self>;
 
@@ -140,8 +143,11 @@ pub trait Key:
     }
 }
 
+/// [`Value`] is required to implement [`Clone`].
+/// 
+/// If cloning a [`Value`] is expensive, wrap it with [`std::sync::Arc`].
 #[expect(unused_variables)]
-pub trait Value: Sized + Send + Sync + 'static + std::fmt::Debug {
+pub trait Value: Sized + Send + Sync + 'static + std::fmt::Debug + Clone {
     type Cursor: Cursor<T = Self> = UnimplementedCursor<Self>;
 
     /// memory weight
@@ -352,7 +358,6 @@ impl Cursor for std::io::Cursor<Vec<u8>> {
     fn len(&self) -> usize {
         self.get_ref().len()
     }
-
 }
 
 pub struct PrimitiveCursorVoid;

--- a/foyer-common/src/code.rs
+++ b/foyer-common/src/code.rs
@@ -93,6 +93,8 @@ pub trait Cursor: Send + Sync + 'static + std::io::Read {
 
     fn inner(&self) -> &Self::T;
 
+    fn into_inner(self) -> Self::T;
+
     fn len(&self) -> usize;
 
     fn is_empty(&self) -> bool {
@@ -205,6 +207,10 @@ macro_rules! def_cursor {
 
                     fn inner(&self) -> &Self::T {
                         &self.inner
+                    }
+
+                    fn into_inner(self) -> Self::T {
+                        self.inner
                     }
 
                     fn len(&self) -> usize {
@@ -339,9 +345,14 @@ impl Cursor for std::io::Cursor<Vec<u8>> {
         self.get_ref()
     }
 
+    fn into_inner(self) -> Self::T {
+        self.into_inner()
+    }
+
     fn len(&self) -> usize {
         self.get_ref().len()
     }
+
 }
 
 pub struct PrimitiveCursorVoid;
@@ -357,6 +368,10 @@ impl Cursor for PrimitiveCursorVoid {
 
     fn inner(&self) -> &Self::T {
         &()
+    }
+
+    fn into_inner(self) -> Self::T {
+        ()
     }
 
     fn len(&self) -> usize {
@@ -418,6 +433,10 @@ impl<T: Send + Sync + 'static> Cursor for UnimplementedCursor<T> {
     type T = T;
 
     fn inner(&self) -> &Self::T {
+        unimplemented!()
+    }
+
+    fn into_inner(self) -> Self::T {
         unimplemented!()
     }
 

--- a/foyer-common/src/code.rs
+++ b/foyer-common/src/code.rs
@@ -103,7 +103,7 @@ pub trait Cursor: Send + Sync + 'static + std::io::Read {
 }
 
 /// [`Key`] is required to implement [`Clone`].
-/// 
+///
 /// If cloning a [`Key`] is expensive, wrap it with [`std::sync::Arc`].
 #[expect(unused_variables)]
 pub trait Key:
@@ -144,7 +144,7 @@ pub trait Key:
 }
 
 /// [`Value`] is required to implement [`Clone`].
-/// 
+///
 /// If cloning a [`Value`] is expensive, wrap it with [`std::sync::Arc`].
 #[expect(unused_variables)]
 pub trait Value: Sized + Send + Sync + 'static + std::fmt::Debug + Clone {
@@ -375,9 +375,7 @@ impl Cursor for PrimitiveCursorVoid {
         &()
     }
 
-    fn into_inner(self) -> Self::T {
-        ()
-    }
+    fn into_inner(self) -> Self::T {}
 
     fn len(&self) -> usize {
         0

--- a/foyer-common/src/code.rs
+++ b/foyer-common/src/code.rs
@@ -20,40 +20,6 @@ use paste::paste;
 pub type CodingError = anyhow::Error;
 pub type CodingResult<T> = Result<T, CodingError>;
 
-trait BufMutExt: BufMut {
-    cfg_match! {
-        cfg(target_pointer_width = "16") => {
-            fn put_usize(&mut self, v: usize) {
-                self.put_u16(v as u16);
-            }
-
-            fn put_isize(&mut self, v: isize) {
-                self.put_i16(v as i16);
-            }
-        }
-        cfg(target_pointer_width = "32") => {
-            fn put_usize(&mut self, v: usize) {
-                self.put_u32(v as u32);
-            }
-
-            fn put_isize(&mut self, v: isize) {
-                self.put_i32(v as i32);
-            }
-        }
-        cfg(target_pointer_width = "64") => {
-            fn put_usize(&mut self, v: usize) {
-                self.put_u64(v as u64);
-            }
-
-            fn put_isize(&mut self, v: isize) {
-                self.put_i64(v as i64);
-            }
-        }
-    }
-}
-
-impl<T: Buf> BufExt for T {}
-
 trait BufExt: Buf {
     cfg_match! {
         cfg(target_pointer_width = "16") => {
@@ -81,6 +47,40 @@ trait BufExt: Buf {
 
             fn get_isize(&mut self) -> isize {
                 self.get_i64() as isize
+            }
+        }
+    }
+}
+
+impl<T: Buf> BufExt for T {}
+
+trait BufMutExt: BufMut {
+    cfg_match! {
+        cfg(target_pointer_width = "16") => {
+            fn put_usize(&mut self, v: usize) {
+                self.put_u16(v as u16);
+            }
+
+            fn put_isize(&mut self, v: isize) {
+                self.put_i16(v as i16);
+            }
+        }
+        cfg(target_pointer_width = "32") => {
+            fn put_usize(&mut self, v: usize) {
+                self.put_u32(v as u32);
+            }
+
+            fn put_isize(&mut self, v: isize) {
+                self.put_i32(v as i32);
+            }
+        }
+        cfg(target_pointer_width = "64") => {
+            fn put_usize(&mut self, v: usize) {
+                self.put_u64(v as u64);
+            }
+
+            fn put_isize(&mut self, v: isize) {
+                self.put_i64(v as i64);
             }
         }
     }

--- a/foyer-memory/src/lib.rs
+++ b/foyer-memory/src/lib.rs
@@ -218,7 +218,7 @@ mod tests {
         }
     }
 
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq, Clone)]
     struct V(usize);
 
     impl Value for V {

--- a/foyer-storage/src/admission/mod.rs
+++ b/foyer-storage/src/admission/mod.rs
@@ -18,13 +18,25 @@ use foyer_common::code::{Key, Value};
 
 use crate::{catalog::Catalog, metrics::Metrics};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AdmissionContext<K>
 where
     K: Key,
 {
     pub catalog: Arc<Catalog<K>>,
     pub metrics: Arc<Metrics>,
+}
+
+impl<K> Clone for AdmissionContext<K>
+where
+    K: Key,
+{
+    fn clone(&self) -> Self {
+        Self {
+            catalog: self.catalog.clone(),
+            metrics: self.metrics.clone(),
+        }
+    }
 }
 
 #[expect(unused_variables)]

--- a/foyer-storage/src/reinsertion/mod.rs
+++ b/foyer-storage/src/reinsertion/mod.rs
@@ -18,13 +18,25 @@ use foyer_common::code::{Key, Value};
 
 use crate::{catalog::Catalog, metrics::Metrics};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReinsertionContext<K>
 where
     K: Key,
 {
     pub catalog: Arc<Catalog<K>>,
     pub metrics: Arc<Metrics>,
+}
+
+impl<K> Clone for ReinsertionContext<K>
+where
+    K: Key,
+{
+    fn clone(&self) -> Self {
+        Self {
+            catalog: self.catalog.clone(),
+            metrics: self.metrics.clone(),
+        }
+    }
 }
 
 #[expect(unused_variables)]


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

For simplicity, foyer requires `Key` and `Value` to impl `Clone`. If cloning is expensive, user should wrap them with `std::sync::Arc`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have passed `make check` and `make test` or `make all` in my local envirorment.

## Related issues or PRs (optional)
