### PR TITLE
feat: introduce time-series distribution args to bench tool

### DIFF
--- a/foyer-storage-bench/Cargo.toml
+++ b/foyer-storage-bench/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { workspace = true }
 tracing = "0.1"
 tracing-opentelemetry = { version = "0.22", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+zipf = "7"
 
 [features]
 deadlock = ["parking_lot/deadlock_detection", "foyer-storage/deadlock"]

--- a/foyer-storage-bench/src/main.rs
+++ b/foyer-storage-bench/src/main.rs
@@ -22,6 +22,7 @@ mod text;
 mod utils;
 
 use std::{
+    collections::BTreeMap,
     fs::create_dir_all,
     ops::Range,
     path::PathBuf,
@@ -44,12 +45,13 @@ use foyer_storage::{
     error::Result,
     reinsertion::{rated_ticket::RatedTicketReinsertionPolicy, ReinsertionPolicy},
     runtime::{RuntimeConfig, RuntimeStore, RuntimeStoreConfig, RuntimeStoreWriter},
-    storage::{Storage, StorageExt, StorageWriter},
+    storage::{AsyncStorageExt, Storage, StorageExt, StorageWriter},
     store::{LfuFsStoreConfig, Store, StoreConfig, StoreWriter},
 };
 use futures::future::join_all;
 use itertools::Itertools;
 use rand::{
+    distributions::Distribution,
     rngs::{OsRng, StdRng},
     Rng, SeedableRng,
 };
@@ -59,6 +61,7 @@ use tokio::sync::broadcast;
 use utils::{detect_fs_type, dev_stat_path, file_stat_path, iostat, FsType};
 
 #[derive(Parser, Debug, Clone)]
+#[command(author, version, about)]
 pub struct Args {
     /// dir for cache data
     #[arg(short, long)]
@@ -152,6 +155,22 @@ pub struct Args {
     /// available values: "none", "zstd"
     #[arg(long, default_value = "none")]
     compression: String,
+
+    /// Time-series operation distribution.
+    ///
+    /// Available values: "none", "uniform", "zipf".
+    ///
+    /// If "uniform" or "zipf" is used, operations will be performed in async mode.
+    #[arg(long, default_value = "none")]
+    distribution: String,
+
+    /// For `--distribution zipf` only.
+    #[arg(long, default_value_t = 100)]
+    distribution_zipf_n: usize,
+
+    /// For `--distribution zipf` only.
+    #[arg(long, default_value_t = 0.5)]
+    distribution_zipf_s: f64,
 }
 
 #[derive(Debug)]
@@ -367,6 +386,47 @@ where
     }
 }
 
+#[derive(Debug)]
+enum TimeSeriesDistribution {
+    None,
+    Uniform {
+        interval: Duration,
+    },
+    Zipf {
+        n: usize,
+        s: f64,
+        interval: Duration,
+    },
+}
+
+impl TimeSeriesDistribution {
+    fn new(args: &Args) -> Self {
+        match args.distribution.as_str() {
+            "none" => TimeSeriesDistribution::None,
+            "uniform" => {
+                // interval = 1 / freq = 1 / (rate / size) = size / rate
+                let interval = ((args.entry_size_min + args.entry_size_max) >> 1) as f64
+                    / (args.w_rate * 1024.0 * 1024.0);
+                let interval = Duration::from_secs_f64(interval);
+                TimeSeriesDistribution::Uniform { interval }
+            }
+            "zipf" => {
+                // interval = 1 / freq = 1 / (rate / size) = size / rate
+                let interval = ((args.entry_size_min + args.entry_size_max) >> 1) as f64
+                    / (args.w_rate * 1024.0 * 1024.0);
+                let interval = Duration::from_secs_f64(interval);
+                display_zipf_sample(args.distribution_zipf_n, args.distribution_zipf_s);
+                TimeSeriesDistribution::Zipf {
+                    n: args.distribution_zipf_n,
+                    s: args.distribution_zipf_s,
+                    interval,
+                }
+            }
+            other => panic!("unsupported distribution: {}", other),
+        }
+    }
+}
+
 struct Context {
     w_rate: Option<f64>,
     r_rate: Option<f64>,
@@ -374,6 +434,7 @@ struct Context {
     entry_size_range: Range<usize>,
     lookup_range: u64,
     time: u64,
+    distribution: TimeSeriesDistribution,
     metrics: Metrics,
 }
 
@@ -637,14 +698,17 @@ async fn bench(
         .map(|_| AtomicU64::default())
         .collect_vec();
 
+    let distribution = TimeSeriesDistribution::new(&args);
+
     let context = Arc::new(Context {
         w_rate,
         r_rate,
+        lookup_range: args.lookup_range,
         counts,
         entry_size_range: args.entry_size_min..args.entry_size_max + 1,
         time: args.time,
+        distribution,
         metrics: metrics.clone(),
-        lookup_range: args.lookup_range,
     });
 
     let w_handles = (0..args.writers)
@@ -675,9 +739,38 @@ async fn write(
 
     let mut limiter = context.w_rate.map(RateLimiter::new);
     let step = context.counts.len() as u64;
-    let count = &context.counts[id as usize];
+
+    const K: usize = 100;
+    const G: usize = 10;
+
+    let zipf_intervals = match context.distribution {
+        TimeSeriesDistribution::Zipf { n, s, interval } => {
+            let histogram = gen_zipf_histogram(n, s, G, n * K);
+
+            let loop_interval = Duration::from_secs_f64(interval.as_secs_f64() * K as f64);
+            let group_cnt = K / G;
+            let group_interval = interval.as_secs_f64() * group_cnt as f64;
+
+            let intervals = histogram
+                .values()
+                .copied()
+                .map(|ratio| Duration::from_secs_f64(group_interval / (ratio * K as f64)))
+                .collect_vec();
+
+            if id == 0 {
+                println!("loop interval: {loop_interval:?}, zipf intervals: {intervals:?}");
+            }
+
+            Some(intervals)
+        }
+        _ => None,
+    };
+
+    let mut c = 0;
 
     loop {
+        let l = Instant::now();
+
         match stop.try_recv() {
             Err(broadcast::error::TryRecvError::Empty) => {}
             _ => return,
@@ -686,7 +779,6 @@ async fn write(
             return;
         }
 
-        let c = count.load(Ordering::Relaxed);
         let idx = id + step * c;
         // TODO(MrCroxx): Use random content?
         let entry_size = OsRng.gen_range(context.entry_size_range.clone());
@@ -696,20 +788,43 @@ async fn write(
         }
 
         let time = Instant::now();
-        let inserted = store.insert(idx, data).await.unwrap();
-        let lat = time.elapsed().as_micros() as u64;
-        count.store(c + 1, Ordering::Relaxed);
-        if let Err(e) = context.metrics.insert_lats.write().record(lat) {
-            tracing::error!("metrics error: {:?}, value: {}", e, lat);
+        let ctx = context.clone();
+        let callback = move |res: Result<bool>| async move {
+            let inserted = res.unwrap();
+            let lat = time.elapsed().as_micros() as u64;
+            ctx.counts[id as usize].fetch_add(1, Ordering::Relaxed);
+            if let Err(e) = ctx.metrics.insert_lats.write().record(lat) {
+                tracing::error!("metrics error: {:?}, value: {}", e, lat);
+            }
+
+            if inserted {
+                ctx.metrics.insert_ios.fetch_add(1, Ordering::Relaxed);
+                ctx.metrics
+                    .insert_bytes
+                    .fetch_add(entry_size, Ordering::Relaxed);
+            }
+        };
+
+        let elapsed = l.elapsed();
+
+        match &context.distribution {
+            TimeSeriesDistribution::None => {
+                let res = store.insert(idx, data).await;
+                callback(res).await;
+            }
+            TimeSeriesDistribution::Uniform { interval } => {
+                store.insert_async_with_callback(idx, data, callback);
+                tokio::time::sleep(interval.saturating_sub(elapsed)).await;
+            }
+            TimeSeriesDistribution::Zipf { .. } => {
+                store.insert_async_with_callback(idx, data, callback);
+                let intervals = zipf_intervals.as_ref().unwrap();
+                let group = (c as usize % K) / (K / G);
+                tokio::time::sleep(intervals[group].saturating_sub(elapsed)).await;
+            }
         }
 
-        if inserted {
-            context.metrics.insert_ios.fetch_add(1, Ordering::Relaxed);
-            context
-                .metrics
-                .insert_bytes
-                .fetch_add(entry_size, Ordering::Relaxed);
-        }
+        c += 1;
     }
 }
 
@@ -772,4 +887,59 @@ async fn read(
 
         tokio::task::consume_budget().await;
     }
+}
+
+fn gen_zipf_histogram(n: usize, s: f64, groups: usize, samples: usize) -> BTreeMap<usize, f64> {
+    let step = n / groups;
+
+    let mut rng = rand::thread_rng();
+    let zipf = zipf::ZipfDistribution::new(n, s).unwrap();
+    let mut data: BTreeMap<usize, usize> = BTreeMap::default();
+    for _ in 0..samples {
+        let v = zipf.sample(&mut rng);
+        let g = std::cmp::min(v / step, groups);
+        *data.entry(g).or_default() += 1;
+    }
+    let mut histogram: BTreeMap<usize, f64> = BTreeMap::default();
+    for group in 0..groups {
+        histogram.insert(
+            group,
+            data.get(&group).copied().unwrap_or_default() as f64 / samples as f64,
+        );
+    }
+    histogram
+}
+
+fn display_zipf_sample(n: usize, s: f64) {
+    const W: usize = 100;
+    const H: usize = 10;
+
+    let samples = n * 1000;
+
+    let histogram = gen_zipf_histogram(n, s, H, samples);
+
+    let max = histogram.values().copied().fold(0.0, f64::max);
+
+    println!("zipf's diagram [N = {n}][s = {s}][samples = {}]", n * 1000);
+
+    for (g, ratio) in histogram {
+        let shares = (ratio / max * W as f64) as usize;
+        let bar: String = if shares != 0 {
+            "=".repeat(shares)
+        } else {
+            ".".to_string()
+        };
+        println!(
+            "{:3} : {:6} : {:6.3}% : {}",
+            g,
+            (samples as f64 * ratio) as usize,
+            ratio * 100.0,
+            bar
+        );
+    }
+}
+
+#[test]
+fn zipf() {
+    display_zipf_sample(1000, 0.5);
 }

--- a/foyer-storage/src/flusher.rs
+++ b/foyer-storage/src/flusher.rs
@@ -192,6 +192,10 @@ where
 
     #[tracing::instrument(skip(self))]
     async fn update_catalog(&self, entries: Vec<PositionedEntry<K, V>>) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+
         // record fully flushed bytes by the way
         let mut bytes = 0;
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

This PR introduce some args to the bench tool to set the time-series distribution. 

For example, the user can generate a workload with the Zipf's Law time-series distribution with:

```bash
rm -rf /p44pro/foyer && cargo build --release && RUST_BACKTRACE=1 RUST_LOG=warn ./target/release/foyer-storage-bench --dir /p44pro/foyer --capacity 204800 --region-size 64 --lookup-range 10000 --flushers 12 --reclaimers 12 --time 180 --writers 64 --w-rate 8 --ticket-insert-rate-limit 500 --readers 1024 --r-rate 1 --runtime --metrics --compression none --io-size 262144 --distribution zipf --distribution-zipf-s 0.8
```

The bench tool will give the histogram of samples and the distribution of intervals:

```
zipf's diagram [N = 100][s = 0.8][samples = 100000]
  0 :  42058 : 42.058% : ====================================================================================================
  1 :  14773 : 14.773% : ===================================
  2 :   9731 :  9.731% : =======================
  3 :   7199 :  7.200% : =================
  4 :   5851 :  5.851% : =============
  5 :   5005 :  5.005% : ===========
  6 :   4413 :  4.413% : ==========
  7 :   3910 :  3.910% : =========
  8 :   3571 :  3.571% : ========
  9 :   3172 :  3.172% : =======
loop interval: 781.25ms, zipf intervals:
    [ 42 ==> 1.855ms   ]
    [ 15 ==> 5.191ms   ]
    [ 10 ==> 8.206ms   ]
    [  7 ==> 11.082ms  ]
    [  6 ==> 13.730ms  ]
    [  5 ==> 15.501ms  ]
    [  4 ==> 17.837ms  ]
    [  4 ==> 18.825ms  ]
    [  3 ==> 23.603ms  ]
    [  3 ==> 23.046ms  ]
```



Full args:

```
storage engine bench tool for foyer - the hybrid cache for Rust

Usage: foyer-storage-bench [OPTIONS] --dir <DIR>

Options:
  -d, --dir <DIR>
          dir for cache data
      --capacity <CAPACITY>
          (MiB) [default: 1024]
  -t, --time <TIME>
          (s) [default: 60]
      --report-interval <REPORT_INTERVAL>
          (s) [default: 2]
      --iostat-dev <IOSTAT_DEV>
          Some filesystem (e.g. btrfs) can span across multiple block devices and it's hard to decide which device to moitor. Use this argument to specify which block device to monitor [default: ]
      --w-rate <W_RATE>
          (MiB) [default: 0]
      --r-rate <R_RATE>
          (MiB) [default: 0]
      --entry-size-min <ENTRY_SIZE_MIN>
          [default: 65536]
      --entry-size-max <ENTRY_SIZE_MAX>
          [default: 65536]
      --lookup-range <LOOKUP_RANGE>
          [default: 10000]
      --region-size <REGION_SIZE>
          (MiB) [default: 64]
      --flushers <FLUSHERS>
          [default: 4]
      --reclaimers <RECLAIMERS>
          [default: 4]
      --align <ALIGN>
          [default: 4096]
      --io-size <IO_SIZE>
          [default: 16384]
      --writers <WRITERS>
          [default: 16]
      --readers <READERS>
          [default: 16]
      --recover-concurrency <RECOVER_CONCURRENCY>
          [default: 16]
      --ticket-insert-rate-limit <TICKET_INSERT_RATE_LIMIT>
          enable rated ticket admission policy if `ticket_insert_rate_limit` > 0 (MiB/s) [default: 0]
      --ticket-reinsert-rate-limit <TICKET_REINSERT_RATE_LIMIT>
          enable rated ticket reinsetion policy if `ticket_reinsert_rate_limit` > 0 (MiB/s) [default: 0]
      --clean-region-threshold <CLEAN_REGION_THRESHOLD>
          `0` means equal to reclaimer count [default: 0]
      --catalog-bits <CATALOG_BITS>
          Catalog indices sharding bits [default: 6]
      --metrics
          weigher to enable metrics exporter
      --runtime
          use separate runtime
      --compression <COMPRESSION>
          available values: "none", "zstd" [default: none]
      --distribution <DISTRIBUTION>
          Time-series operation distribution [default: none]
      --distribution-zipf-n <DISTRIBUTION_ZIPF_N>
          For `--distribution zipf` only [default: 100]
      --distribution-zipf-s <DISTRIBUTION_ZIPF_S>
          For `--distribution zipf` only [default: 0.5]
  -h, --help
          Print help (see more with '--help')
  -V, --version
          Print version
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have passed `make check` and `make test` or `make all` in my local envirorment.

## Related issues or PRs (optional)
