### PR TITLE
feat: introduce blocking notify

### DIFF
--- a/foyer-experimental/Cargo.toml
+++ b/foyer-experimental/Cargo.toml
@@ -15,7 +15,7 @@ normal = ["foyer-workspace-hack"]
 [dependencies]
 anyhow = "1.0"
 bytes = "1"
-crossbeam = { version = "0.8", features = ["crossbeam-channel"] }
+crossbeam = { version = "0.8", features = ["std", "crossbeam-channel"] }
 foyer-workspace-hack = { version = "0.2", path = "../foyer-workspace-hack" }
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 paste = "1.0"

--- a/foyer-experimental/src/lib.rs
+++ b/foyer-experimental/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod buf;
 pub mod error;
 pub mod metrics;
+pub mod notify;
 pub mod wal;
 
 #[cfg(not(madsim))]

--- a/foyer-experimental/src/notify.rs
+++ b/foyer-experimental/src/notify.rs
@@ -1,0 +1,129 @@
+//  Copyright 2024 MrCroxx
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, OnceLock,
+    },
+    thread::{current, park, Thread},
+};
+
+use crossbeam::utils::Backoff;
+
+/// A multi-producer-single-consumer blocking notify implementation.
+#[derive(Debug, Default, Clone)]
+pub struct Notify {
+    ready: Arc<AtomicBool>,
+    thread: Arc<OnceLock<Thread>>,
+}
+
+impl Notify {
+    pub fn notified(&self) -> Notified {
+        self.thread.set(current()).unwrap();
+        Notified::new(self.ready.clone())
+    }
+
+    pub fn notify(&self) {
+        self.ready.store(true, Ordering::SeqCst);
+        self.thread.get().unwrap().unpark();
+    }
+}
+
+#[derive(Debug)]
+pub struct Notified {
+    ready: Arc<AtomicBool>,
+    backoff: Backoff,
+}
+
+impl Notified {
+    fn new(ready: Arc<AtomicBool>) -> Self {
+        Self {
+            ready,
+            backoff: Backoff::default(),
+        }
+    }
+
+    pub fn wait(&self) {
+        while !self.ready.load(Ordering::SeqCst) {
+            if self.backoff.is_completed() {
+                park();
+            } else {
+                self.backoff.snooze();
+            }
+        }
+        self.ready.store(false, Ordering::SeqCst);
+        self.backoff.reset();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::Arc,
+        thread::{sleep, spawn},
+        time::Duration,
+    };
+
+    use super::*;
+
+    #[test]
+    fn assert_notify_send_sync_static() {
+        fn is_send_sync_static<T: Send + Sync + 'static>() {}
+        is_send_sync_static::<Notify>()
+    }
+
+    #[test]
+    fn test_notify_buffer_one() {
+        let notify = Notify::default();
+
+        let notified = notify.notified();
+
+        notify.notify();
+
+        notified.wait();
+    }
+
+    #[test]
+    fn test_notify_buffer_one_block() {
+        let handle = spawn(|| {
+            let notify = Notify::default();
+
+            let notified = notify.notified();
+
+            notify.notify();
+
+            notified.wait();
+            notified.wait();
+        });
+
+        sleep(Duration::from_secs(1));
+
+        assert!(!handle.is_finished());
+    }
+
+    #[test]
+    fn test_notify() {
+        let notify = Arc::new(Notify::default());
+        let n = notify.clone();
+        let handle = spawn(move || {
+            let notified = n.notified();
+
+            notified.wait();
+        });
+        sleep(Duration::from_secs(1));
+        notify.notify();
+        handle.join().unwrap();
+    }
+}

--- a/foyer-experimental/src/wal.rs
+++ b/foyer-experimental/src/wal.rs
@@ -334,6 +334,3 @@ impl TombstoneLogFlushNotifier {
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod tests {}


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

`Notify` is like `tokio::sync::Notify` but is for non-async environment and is for multi-producer single-consumer only.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have passed `make check` and `make test` or `make all` in my local envirorment.

## Related issues or PRs (optional)
