### PR TITLE
feat: introduce event listener for foyer-memory cache

### DIFF
--- a/foyer-memory/src/event.rs
+++ b/foyer-memory/src/event.rs
@@ -1,0 +1,58 @@
+//  Copyright 2024 MrCroxx
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::marker::PhantomData;
+
+use crate::{Key, Value};
+
+pub trait CacheEventListener: Send + Sync + 'static {
+    type Key: Key;
+    type Value: Value;
+    type Context: Send + Sync + 'static;
+
+    /// The function is called when an entry is released by the cache and all external users.
+    ///
+    /// The arguments includes the key, value and context with ownership.
+    fn on_release(&self, key: Self::Key, value: Self::Value, context: Self::Context, charges: usize);
+}
+
+pub struct DefaultCacheEventListener<K, V, C>(PhantomData<(K, V, C)>)
+where
+    K: Key,
+    V: Value,
+    C: Send + Sync + 'static;
+
+impl<K, V, C> Default for DefaultCacheEventListener<K, V, C>
+where
+    K: Key,
+    V: Value,
+    C: Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<K, V, C> CacheEventListener for DefaultCacheEventListener<K, V, C>
+where
+    K: Key,
+    V: Value,
+    C: Send + Sync + 'static,
+{
+    type Key = K;
+    type Value = V;
+    type Context = C;
+
+    fn on_release(&self, _key: Self::Key, _value: Self::Value, _context: Self::Context, _charges: usize) {}
+}

--- a/foyer-memory/src/eviction/fifo.rs
+++ b/foyer-memory/src/eviction/fifo.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::{fmt::Debug, hash::BuildHasher, ptr::NonNull};
+use std::{fmt::Debug, ptr::NonNull};
 
 use foyer_intrusive::{
     collections::dlist::{Dlist, DlistLink},
@@ -20,7 +20,6 @@ use foyer_intrusive::{
 };
 
 use crate::{
-    cache::CacheConfig,
     eviction::Eviction,
     handle::{BaseHandle, Handle},
     Key, Value,
@@ -97,7 +96,7 @@ where
     type Handle = FifoHandle<K, V>;
     type Config = FifoConfig;
 
-    unsafe fn new<S: BuildHasher + Send + Sync + 'static>(_: &CacheConfig<Self, S>) -> Self
+    unsafe fn new(_capacity: usize, _config: &Self::Config) -> Self
     where
         Self: Sized,
     {
@@ -159,7 +158,7 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use ahash::RandomState;
+
     use itertools::Itertools;
 
     use super::*;
@@ -196,15 +195,7 @@ pub mod tests {
         unsafe {
             let ptrs = (0..8).map(|i| new_test_fifo_handle_ptr(i, i)).collect_vec();
 
-            let config = CacheConfig {
-                capacity: 0,
-                shards: 1,
-                eviction_config: FifoConfig {},
-                object_pool_capacity: 0,
-                hash_builder: RandomState::default(),
-            };
-
-            let mut fifo = TestFifo::new(&config);
+            let mut fifo = TestFifo::new(100, &FifoConfig {});
 
             // 0, 1, 2, 3
             fifo.push(ptrs[0]);

--- a/foyer-memory/src/eviction/mod.rs
+++ b/foyer-memory/src/eviction/mod.rs
@@ -12,9 +12,9 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::{hash::BuildHasher, ptr::NonNull};
+use std::ptr::NonNull;
 
-use crate::{cache::CacheConfig, handle::Handle};
+use crate::handle::Handle;
 
 /// The lifetime of `handle: Self::H` is managed by [`Indexer`].
 ///
@@ -26,7 +26,7 @@ pub trait Eviction: Send + Sync + 'static {
     /// Create a new empty eviction container.
     ///
     /// # Safety
-    unsafe fn new<S: BuildHasher + Send + Sync + 'static>(config: &CacheConfig<Self, S>) -> Self
+    unsafe fn new(capacity: usize, config: &Self::Config) -> Self
     where
         Self: Sized;
 

--- a/foyer-memory/src/handle.rs
+++ b/foyer-memory/src/handle.rs
@@ -94,9 +94,14 @@ where
 
     /// Take key and value from the handle and reset it to the uninited state.
     #[inline(always)]
-    pub fn take(&mut self) -> (K, V) {
+    pub fn take(&mut self) -> (K, V, C, usize) {
         debug_assert!(self.entry.is_some());
-        unsafe { self.entry.take().map(|(key, value, _)| (key, value)).unwrap_unchecked() }
+        unsafe {
+            self.entry
+                .take()
+                .map(|(key, value, context)| (key, value, context, self.charge))
+                .unwrap_unchecked()
+        }
     }
 
     /// Return `true` if the handle is inited.

--- a/foyer-memory/src/lib.rs
+++ b/foyer-memory/src/lib.rs
@@ -66,6 +66,7 @@
 //! destroyed.
 
 pub mod cache;
+pub mod event;
 pub mod eviction;
 pub mod handle;
 pub mod indexer;


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Introduce event listener for foyer-memory. Currently, it only reports entry release events.  More events can be reported as needed in the future.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have passed `make check` and `make test` or `make all` in my local envirorment.

## Related issues or PRs (optional)
#270 
