### PR TITLE
refactor: introduce a unified cache context

### DIFF
--- a/foyer-memory/src/context.rs
+++ b/foyer-memory/src/context.rs
@@ -1,0 +1,30 @@
+//  Copyright 2024 MrCroxx
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+pub enum CacheContext {
+    /// The default context shared by all eviction container implementations.
+    Default,
+    LruPriorityLow,
+}
+
+impl Default for CacheContext {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+/// The overhead of `Context` itself and the conversion should be light.
+pub trait Context: From<CacheContext> + Into<CacheContext> + Send + Sync + 'static {}
+
+impl<T> Context for T where T: From<CacheContext> + Into<CacheContext> + Send + Sync + 'static {}

--- a/foyer-memory/src/eviction/fifo.rs
+++ b/foyer-memory/src/eviction/fifo.rs
@@ -22,10 +22,23 @@ use foyer_intrusive::{
 use crate::{
     eviction::Eviction,
     handle::{BaseHandle, Handle},
-    Key, Value,
+    CacheContext, Key, Value,
 };
 
-pub type FifoContext = ();
+#[derive(Debug, Default)]
+pub struct FifoContext;
+
+impl From<CacheContext> for FifoContext {
+    fn from(_: CacheContext) -> Self {
+        Self
+    }
+}
+
+impl From<FifoContext> for CacheContext {
+    fn from(_: FifoContext) -> Self {
+        CacheContext::Default
+    }
+}
 
 pub struct FifoHandle<K, V>
 where
@@ -182,7 +195,7 @@ pub mod tests {
 
     unsafe fn new_test_fifo_handle_ptr(key: u64, value: u64) -> NonNull<TestFifoHandle> {
         let mut handle = Box::new(TestFifoHandle::new());
-        handle.init(0, key, value, 1, ());
+        handle.init(0, key, value, 1, FifoContext);
         NonNull::new_unchecked(Box::into_raw(handle))
     }
 

--- a/foyer-memory/src/eviction/lfu.rs
+++ b/foyer-memory/src/eviction/lfu.rs
@@ -24,7 +24,7 @@ use foyer_intrusive::{
 use crate::{
     eviction::Eviction,
     handle::{BaseHandle, Handle},
-    Key, Value,
+    CacheContext, Key, Value,
 };
 
 #[derive(Debug, Clone)]
@@ -46,7 +46,20 @@ pub struct LfuConfig {
     pub cmsketch_confidence: f64,
 }
 
-pub type LfuContext = ();
+#[derive(Debug, Default)]
+pub struct LfuContext;
+
+impl From<CacheContext> for LfuContext {
+    fn from(_: CacheContext) -> Self {
+        Self
+    }
+}
+
+impl From<LfuContext> for CacheContext {
+    fn from(_: LfuContext) -> Self {
+        CacheContext::Default
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 enum Queue {
@@ -473,7 +486,7 @@ mod tests {
             let ptrs = (0..100)
                 .map(|i| {
                     let mut handle = Box::new(TestLfuHandle::new());
-                    handle.init(i, i, i, 1, ());
+                    handle.init(i, i, i, 1, LfuContext);
                     NonNull::new_unchecked(Box::into_raw(handle))
                 })
                 .collect_vec();

--- a/foyer-memory/src/eviction/lru.rs
+++ b/foyer-memory/src/eviction/lru.rs
@@ -23,7 +23,7 @@ use foyer_intrusive::{
 use crate::{
     eviction::Eviction,
     handle::{BaseHandle, Handle},
-    Key, Value,
+    CacheContext, Key, Value,
 };
 
 #[derive(Debug)]
@@ -45,9 +45,21 @@ pub enum LruContext {
     LowPriority,
 }
 
-impl Default for LruContext {
-    fn default() -> Self {
-        Self::HighPriority
+impl From<CacheContext> for LruContext {
+    fn from(value: CacheContext) -> Self {
+        match value {
+            CacheContext::Default => Self::HighPriority,
+            CacheContext::LruPriorityLow => Self::LowPriority,
+        }
+    }
+}
+
+impl From<LruContext> for CacheContext {
+    fn from(value: LruContext) -> Self {
+        match value {
+            LruContext::HighPriority => CacheContext::Default,
+            LruContext::LowPriority => CacheContext::LruPriorityLow,
+        }
     }
 }
 

--- a/foyer-memory/src/handle.rs
+++ b/foyer-memory/src/handle.rs
@@ -14,7 +14,7 @@
 
 use bitflags::bitflags;
 
-use crate::{Context, Key, Value};
+use crate::{context::Context, Key, Value};
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/foyer-memory/src/lib.rs
+++ b/foyer-memory/src/lib.rs
@@ -69,13 +69,12 @@
 
 pub trait Key: Send + Sync + 'static + std::hash::Hash + Eq + Ord {}
 pub trait Value: Send + Sync + 'static {}
-pub trait Context: Send + Sync + 'static + Default {}
 
 impl<T: Send + Sync + 'static + std::hash::Hash + Eq + Ord> Key for T {}
 impl<T: Send + Sync + 'static> Value for T {}
-impl<T: Send + Sync + 'static + Default> Context for T {}
 
 mod cache;
+mod context;
 mod eviction;
 mod handle;
 mod indexer;

--- a/foyer-memory/src/listener.rs
+++ b/foyer-memory/src/listener.rs
@@ -14,42 +14,38 @@
 
 use std::marker::PhantomData;
 
-use crate::{Context, Key, Value};
+use crate::{CacheContext, Key, Value};
 
-pub trait CacheEventListener<K, V, C>: Send + Sync + 'static
+pub trait CacheEventListener<K, V>: Send + Sync + 'static
 where
     K: Key,
     V: Value,
-    C: Context,
 {
     /// The function is called when an entry is released by the cache and all external users.
     ///
     /// The arguments includes the key and value with ownership.
-    fn on_release(&self, key: K, value: V, context: C, charges: usize);
+    fn on_release(&self, key: K, value: V, context: CacheContext, charges: usize);
 }
 
-pub struct DefaultCacheEventListener<K, V, C>(PhantomData<(K, V, C)>)
+pub struct DefaultCacheEventListener<K, V>(PhantomData<(K, V)>)
 where
     K: Key,
-    V: Value,
-    C: Context;
+    V: Value;
 
-impl<K, V, C> Default for DefaultCacheEventListener<K, V, C>
+impl<K, V> Default for DefaultCacheEventListener<K, V>
 where
     K: Key,
     V: Value,
-    C: Context,
 {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<K, V, C> CacheEventListener<K, V, C> for DefaultCacheEventListener<K, V, C>
+impl<K, V> CacheEventListener<K, V> for DefaultCacheEventListener<K, V>
 where
     K: Key,
     V: Value,
-    C: Context,
 {
-    fn on_release(&self, _key: K, _value: V, _context: C, _charges: usize) {}
+    fn on_release(&self, _key: K, _value: V, _context: CacheContext, _charges: usize) {}
 }

--- a/foyer-memory/src/prelude.rs
+++ b/foyer-memory/src/prelude.rs
@@ -25,29 +25,27 @@ use crate::{
     listener::DefaultCacheEventListener,
 };
 
-pub type FifoCache<K, V, L = DefaultCacheEventListener<K, V, FifoContext>, S = RandomState> =
+pub type FifoCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     Cache<K, V, FifoHandle<K, V>, Fifo<K, V>, HashTableIndexer<K, FifoHandle<K, V>>, L, S>;
-pub type FifoCacheConfig<K, V, L = DefaultCacheEventListener<K, V, FifoContext>, S = RandomState> =
-    CacheConfig<Fifo<K, V>, L, S>;
-pub type FifoCacheEntry<K, V, L = DefaultCacheEventListener<K, V, FifoContext>, S = RandomState> =
+pub type FifoCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> = CacheConfig<Fifo<K, V>, L, S>;
+pub type FifoCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     CacheEntry<K, V, FifoHandle<K, V>, Fifo<K, V>, HashTableIndexer<K, FifoHandle<K, V>>, L, S>;
 
-pub type LruCache<K, V, L = DefaultCacheEventListener<K, V, LruContext>, S = RandomState> =
+pub type LruCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     Cache<K, V, LruHandle<K, V>, Lru<K, V>, HashTableIndexer<K, LruHandle<K, V>>, L, S>;
-pub type LruCacheConfig<K, V, L = DefaultCacheEventListener<K, V, LruContext>, S = RandomState> =
-    CacheConfig<Lru<K, V>, L, S>;
-pub type LruCacheEntry<K, V, L = DefaultCacheEventListener<K, V, LruContext>, S = RandomState> =
+pub type LruCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> = CacheConfig<Lru<K, V>, L, S>;
+pub type LruCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     CacheEntry<K, V, LruHandle<K, V>, Lru<K, V>, HashTableIndexer<K, LruHandle<K, V>>, L, S>;
 
-pub type LfuCache<K, V, L = DefaultCacheEventListener<K, V, LfuContext>, S = RandomState> =
+pub type LfuCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     Cache<K, V, LfuHandle<K, V>, Lfu<K, V>, HashTableIndexer<K, LfuHandle<K, V>>, L, S>;
-pub type LfuCacheConfig<K, V, L = DefaultCacheEventListener<K, V, LfuContext>, S = RandomState> =
-    CacheConfig<Lfu<K, V>, L, S>;
-pub type LfuCacheEntry<K, V, L = DefaultCacheEventListener<K, V, LfuContext>, S = RandomState> =
+pub type LfuCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> = CacheConfig<Lfu<K, V>, L, S>;
+pub type LfuCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     CacheEntry<K, V, LfuHandle<K, V>, Lfu<K, V>, HashTableIndexer<K, LfuHandle<K, V>>, L, S>;
 
 pub use crate::{
     cache::Entry,
+    context::CacheContext,
     eviction::{
         fifo::{FifoConfig, FifoContext},
         lfu::{LfuConfig, LfuContext},


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Introduce a unified `CacheContext` to communicate with all eviction container implementations. Its overhead is supposed to be light.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
