### PR TITLE
feat: add eviction alg hit ratio bench

### DIFF
--- a/foyer-intrusive/src/lib.rs
+++ b/foyer-intrusive/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(ptr_metadata)]
 #![feature(trait_alias)]
 #![feature(lint_reasons)]
+#![feature(offset_of)]
 #![expect(clippy::new_without_default)]
 
 pub use memoffset::offset_of;

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -25,8 +25,6 @@ itertools = "0.12"
 libc = "0.2"
 parking_lot = "0.12"
 tokio = { workspace = true }
-
-
 [dev-dependencies]
 bytesize = "1"
 clap = { version = "4", features = ["derive"] }

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -26,6 +26,7 @@ libc = "0.2"
 parking_lot = "0.12"
 tokio = { workspace = true }
 
+
 [dev-dependencies]
 bytesize = "1"
 clap = { version = "4", features = ["derive"] }
@@ -33,6 +34,12 @@ hdrhistogram = "7"
 rand = "0.8"
 rand_mt = "4.2.1"
 tempfile = "3"
+zipf = "7.0.1"
+moka = { version = "0", features = ["sync"] }
 
 [features]
 deadlock = ["parking_lot/deadlock_detection"]
+
+[[bench]]
+name = "bench_hit_ratio"
+harness = false

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -29,11 +29,11 @@ tokio = { workspace = true }
 bytesize = "1"
 clap = { version = "4", features = ["derive"] }
 hdrhistogram = "7"
+moka = { version = "0", features = ["sync"] }
 rand = "0.8"
 rand_mt = "4.2.1"
 tempfile = "3"
 zipf = "7.0.1"
-moka = { version = "0", features = ["sync"] }
 
 [features]
 deadlock = ["parking_lot/deadlock_detection"]

--- a/foyer-memory/benches/bench_hit_ratio.rs
+++ b/foyer-memory/benches/bench_hit_ratio.rs
@@ -72,7 +72,7 @@ fn cache_hit(cache: Arc<Cache<CacheKey, CacheValue>>, keys: Arc<Vec<CacheKey>>) 
     hit as f64 / ITERATIONS as f64
 }
 
-fn moka_cache_hit(cache: &moka::sync::Cache<CacheKey, CacheValue>, keys: &Vec<String>) -> f64 {
+fn moka_cache_hit(cache: &moka::sync::Cache<CacheKey, CacheValue>, keys: &[String]) -> f64 {
     let mut hit = 0;
     for key in keys.iter() {
         let value = cache.get(key);
@@ -184,7 +184,7 @@ fn bench_one(zif_exp: f64, cache_size_percent: f64) {
     print!("{:.2}%\t\t", fifo_hit_ratio * 100.0);
     print!("{:.2}%\t\t", lru_hit_ratio * 100.0);
     print!("{:.2}%\t\t", lfu_hit_ratio * 100.0);
-    print!("{:.2}%\n", moka_hit_ratio * 100.0);
+    println!("{:.2}%", moka_hit_ratio * 100.0);
 }
 
 fn bench_zipf_hit() {

--- a/foyer-memory/benches/bench_hit_ratio.rs
+++ b/foyer-memory/benches/bench_hit_ratio.rs
@@ -1,0 +1,201 @@
+use std::{hash::BuildHasher, sync::Arc};
+
+use ahash::RandomState;
+use foyer_memory::{
+    cache::{LfuCache, LruCache},
+    eviction::Eviction,
+    indexer::Indexer,
+    CacheEventListener, DefaultCacheEventListener, FifoCache, FifoCacheConfig, FifoConfig, GenericCache, Handle,
+    LfuCacheConfig, LfuConfig, LruCacheConfig, LruConfig,
+};
+use rand::{distributions::Distribution, thread_rng};
+
+type CacheKey = String;
+type CacheValue = ();
+
+const ITEMS: usize = 10_000;
+const ITERATIONS: usize = 5_000_000;
+
+const SHARDS: usize = 1;
+const OBJECT_POOL_CAPACITY: usize = 16;
+/*
+inspired by pingora/tinyufo/benches/bench_hit_ratio.rs
+cargo bench --bench bench_hit_ratio
+
+zif_exp, cache_size             fifo            lru             lfu             moka
+0.90, 0.005                     16.26%          19.22%          32.38%          33.46%
+0.90, 0.01                      22.55%          26.21%          38.55%          37.93%
+0.90, 0.05                      41.10%          45.60%          55.45%          55.26%
+0.90,  0.1                      51.11%          55.72%          63.83%          64.21%
+0.90, 0.25                      66.81%          71.17%          76.21%          77.14%
+1.00, 0.005                     26.64%          31.08%          44.14%          45.61%
+1.00, 0.01                      34.37%          39.13%          50.60%          50.67%
+1.00, 0.05                      54.06%          58.79%          66.79%          66.99%
+1.00,  0.1                      63.12%          67.58%          73.92%          74.38%
+1.00, 0.25                      76.14%          79.92%          83.61%          84.33%
+1.05, 0.005                     32.63%          37.68%          50.24%          51.77%
+1.05, 0.01                      40.95%          46.09%          56.75%          57.15%
+1.05, 0.05                      60.47%          65.06%          72.07%          72.36%
+1.05,  0.1                      68.96%          73.15%          78.52%          78.96%
+1.05, 0.25                      80.42%          83.76%          86.79%          87.42%
+1.10, 0.005                     39.02%          44.52%          56.29%          57.90%
+1.10, 0.01                      47.66%          52.99%          62.64%          63.23%
+1.10, 0.05                      66.60%          70.95%          76.94%          77.25%
+1.10,  0.1                      74.26%          78.09%          82.56%          82.93%
+1.10, 0.25                      84.15%          87.06%          89.54%          90.05%
+1.50, 0.005                     81.19%          85.28%          88.91%          89.94%
+1.50, 0.01                      86.91%          89.87%          92.24%          92.78%
+1.50, 0.05                      94.75%          96.04%          96.95%          97.07%
+1.50,  0.1                      96.65%          97.51%          98.06%          98.15%
+1.50, 0.25                      98.35%          98.81%          99.04%          99.09%
+*/
+fn cache_hit<H, E, I, L, S>(
+    cache: Arc<GenericCache<CacheKey, CacheValue, H, E, I, L, S>>,
+    keys: Arc<Vec<CacheKey>>,
+) -> f64
+where
+    H: Handle<Key = CacheKey, Value = CacheValue>,
+    E: Eviction<Handle = H>,
+    I: Indexer<Key = CacheKey, Handle = H>,
+    L: CacheEventListener<CacheKey, CacheValue>,
+    S: BuildHasher + Send + Sync + 'static,
+{
+    let mut hit = 0;
+    for key in keys.iter() {
+        let value = cache.get(key);
+        if value.is_some() {
+            hit += 1;
+        } else {
+            cache.insert(key.clone(), (), 1);
+        }
+    }
+    hit as f64 / ITERATIONS as f64
+}
+
+fn moka_cache_hit(cache: &moka::sync::Cache<CacheKey, CacheValue>, keys: &Vec<String>) -> f64 {
+    let mut hit = 0;
+    for key in keys.iter() {
+        let value = cache.get(key);
+        if value.is_some() {
+            hit += 1;
+        } else {
+            cache.insert(key.clone(), ());
+        }
+    }
+    hit as f64 / ITERATIONS as f64
+}
+
+fn new_fifo_cache(capacity: usize) -> Arc<FifoCache<CacheKey, CacheValue>> {
+    let config = FifoCacheConfig {
+        capacity,
+        shards: SHARDS,
+        eviction_config: FifoConfig {},
+        object_pool_capacity: OBJECT_POOL_CAPACITY,
+        hash_builder: RandomState::default(),
+        event_listener: DefaultCacheEventListener::default(),
+    };
+
+    Arc::new(FifoCache::<CacheKey, CacheValue>::new(config))
+}
+
+fn new_lru_cache(capacity: usize) -> Arc<LruCache<CacheKey, CacheValue>> {
+    let config = LruCacheConfig {
+        capacity,
+        shards: SHARDS,
+        eviction_config: LruConfig {
+            high_priority_pool_ratio: 0.1,
+        },
+        object_pool_capacity: OBJECT_POOL_CAPACITY,
+        hash_builder: RandomState::default(),
+        event_listener: DefaultCacheEventListener::default(),
+    };
+
+    Arc::new(LruCache::<CacheKey, CacheValue>::new(config))
+}
+
+fn new_lfu_cache(capacity: usize) -> Arc<LfuCache<CacheKey, CacheValue>> {
+    let config = LfuCacheConfig {
+        capacity,
+        shards: SHARDS,
+        eviction_config: LfuConfig {
+            window_capacity_ratio: 0.1,
+            protected_capacity_ratio: 0.8,
+            cmsketch_eps: 0.001,
+            cmsketch_confidence: 0.9,
+        },
+        object_pool_capacity: OBJECT_POOL_CAPACITY,
+        hash_builder: RandomState::default(),
+        event_listener: DefaultCacheEventListener::default(),
+    };
+
+    Arc::new(LfuCache::<CacheKey, CacheValue>::new(config))
+}
+
+fn bench_one(zif_exp: f64, cache_size_percent: f64) {
+    print!("{zif_exp:.2}, {cache_size_percent:4}\t\t\t");
+    let mut rng = thread_rng();
+    let zipf = zipf::ZipfDistribution::new(ITEMS, zif_exp).unwrap();
+
+    let cache_size = (ITEMS as f64 * cache_size_percent) as usize;
+
+    let fifo_cache = new_fifo_cache(cache_size);
+    let lru_cache = new_lru_cache(cache_size);
+    let lfu_cache = new_lfu_cache(cache_size);
+    let moka_cache = moka::sync::Cache::new(cache_size as u64);
+
+    let mut keys = Vec::with_capacity(ITERATIONS);
+    for _ in 0..ITERATIONS {
+        let key = zipf.sample(&mut rng).to_string();
+        keys.push(key.clone());
+    }
+
+    let keys = Arc::new(keys);
+
+    // Use multiple threads to simulate concurrent read-through requests.
+    let fifo_cache_hit_handle = std::thread::spawn({
+        let cache = fifo_cache.clone();
+        let keys = keys.clone();
+        move || cache_hit(cache, keys)
+    });
+
+    let lru_cache_hit_handle = std::thread::spawn({
+        let cache = lru_cache.clone();
+        let keys = keys.clone();
+        move || cache_hit(cache, keys)
+    });
+
+    let lfu_cache_hit_handle = std::thread::spawn({
+        let cache = lfu_cache.clone();
+        let keys = keys.clone();
+        move || cache_hit(cache, keys)
+    });
+
+    let moka_cache_hit_handle = std::thread::spawn({
+        let cache = moka_cache.clone();
+        let keys = keys.clone();
+        move || moka_cache_hit(&cache, &keys)
+    });
+
+    let fifo_hit_ratio = fifo_cache_hit_handle.join().unwrap();
+    let lru_hit_ratio = lru_cache_hit_handle.join().unwrap();
+    let lfu_hit_ratio = lfu_cache_hit_handle.join().unwrap();
+    let moka_hit_ratio = moka_cache_hit_handle.join().unwrap();
+
+    print!("{:.2}%\t\t", fifo_hit_ratio * 100.0);
+    print!("{:.2}%\t\t", lru_hit_ratio * 100.0);
+    print!("{:.2}%\t\t", lfu_hit_ratio * 100.0);
+    print!("{:.2}%\n", moka_hit_ratio * 100.0);
+}
+
+fn bench_zipf_hit() {
+    println!("zif_exp, cache_size\t\tfifo\t\tlru\t\tlfu\t\tmoka");
+    for zif_exp in [0.9, 1.0, 1.05, 1.1, 1.5] {
+        for cache_capacity in [0.005, 0.01, 0.05, 0.1, 0.25] {
+            bench_one(zif_exp, cache_capacity);
+        }
+    }
+}
+
+fn main() {
+    bench_zipf_hit();
+}

--- a/foyer-memory/src/lib.rs
+++ b/foyer-memory/src/lib.rs
@@ -74,13 +74,13 @@ pub trait Value: Send + Sync + 'static {}
 impl<T: Send + Sync + 'static + std::hash::Hash + Eq + Ord> Key for T {}
 impl<T: Send + Sync + 'static> Value for T {}
 
-pub mod cache;
-pub mod context;
-pub mod eviction;
-pub mod generic;
+mod cache;
+mod context;
+mod eviction;
+mod generic;
 mod handle;
-pub mod indexer;
-pub mod listener;
+mod indexer;
+mod listener;
 mod metrics;
 mod prelude;
 

--- a/foyer-memory/src/lib.rs
+++ b/foyer-memory/src/lib.rs
@@ -66,6 +66,7 @@
 //! destroyed.
 
 #![feature(trait_alias)]
+#![feature(offset_of)]
 
 pub trait Key: Send + Sync + 'static + std::hash::Hash + Eq + Ord {}
 pub trait Value: Send + Sync + 'static {}
@@ -73,13 +74,13 @@ pub trait Value: Send + Sync + 'static {}
 impl<T: Send + Sync + 'static + std::hash::Hash + Eq + Ord> Key for T {}
 impl<T: Send + Sync + 'static> Value for T {}
 
-mod cache;
-mod context;
-mod eviction;
-mod generic;
+pub mod cache;
+pub mod context;
+pub mod eviction;
+pub mod generic;
 mod handle;
-mod indexer;
-mod listener;
+pub mod indexer;
+pub mod listener;
 mod metrics;
 mod prelude;
 

--- a/foyer-memory/src/prelude.rs
+++ b/foyer-memory/src/prelude.rs
@@ -13,11 +13,9 @@
 //  limitations under the License.
 
 pub use crate::{
-    cache::{Cache, CacheEntry, Entry, EntryState, FifoCache, FifoCacheConfig, LfuCacheConfig, LruCacheConfig},
+    cache::{Cache, CacheEntry, Entry, EntryState, FifoCacheConfig, LfuCacheConfig, LruCacheConfig},
     context::CacheContext,
     eviction::{fifo::FifoConfig, lfu::LfuConfig, lru::LruConfig},
-    generic::GenericCache,
-    handle::Handle,
     listener::{CacheEventListener, DefaultCacheEventListener},
     metrics::Metrics,
 };

--- a/foyer-memory/src/prelude.rs
+++ b/foyer-memory/src/prelude.rs
@@ -13,9 +13,11 @@
 //  limitations under the License.
 
 pub use crate::{
-    cache::{Cache, CacheEntry, Entry, EntryState, FifoCacheConfig, LfuCacheConfig, LruCacheConfig},
+    cache::{Cache, CacheEntry, Entry, EntryState, FifoCache, FifoCacheConfig, LfuCacheConfig, LruCacheConfig},
     context::CacheContext,
     eviction::{fifo::FifoConfig, lfu::LfuConfig, lru::LruConfig},
+    generic::GenericCache,
+    handle::Handle,
     listener::{CacheEventListener, DefaultCacheEventListener},
     metrics::Metrics,
 };

--- a/foyer-storage/src/lib.rs
+++ b/foyer-storage/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(associated_type_defaults)]
 #![feature(box_into_inner)]
 #![feature(try_trait_v2)]
+#![feature(offset_of)]
 
 pub mod admission;
 pub mod buffer;

--- a/foyer-workspace-hack/Cargo.toml
+++ b/foyer-workspace-hack/Cargo.toml
@@ -19,6 +19,7 @@ publish = true
 [dependencies]
 ahash = { version = "0.8" }
 crossbeam-channel = { version = "0.5" }
+crossbeam-epoch = { version = "0.9" }
 crossbeam-utils = { version = "0.8" }
 either = { version = "1", default-features = false, features = ["use_std"] }
 futures-channel = { version = "0.3", features = ["sink"] }


### PR DESCRIPTION
## What's changed and what's your intention?

insipred by https://github.com/cloudflare/pingora/blob/main/tinyufo/benches/bench_hit_ratio.rs

In order to implement new eviction algorithms later, such as s3fifo, we need an intuitive test to demonstrate how these algorithms work.

I also plan to test their performance under real trace datasets later (Tencent Photo Cache, Twitter Cache Trace). Should I include CSV files of around 200KB in the repository?

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
