### PR TITLE
feat: add S3Fifo eviction for memory

### DIFF
--- a/foyer-intrusive/src/core/adapter.rs
+++ b/foyer-intrusive/src/core/adapter.rs
@@ -117,6 +117,8 @@ pub unsafe trait PriorityAdapter: Adapter {
 /// # Examples
 ///
 /// ```
+/// #![feature(offset_of)]
+///
 /// use foyer_intrusive::{intrusive_adapter, key_adapter};
 /// use foyer_intrusive::core::adapter::{Adapter, KeyAdapter, Link};
 /// use foyer_intrusive::core::pointer::Pointer;
@@ -213,6 +215,8 @@ macro_rules! intrusive_adapter {
 /// # Examples
 ///
 /// ```
+/// #![feature(offset_of)]
+///
 /// use foyer_intrusive::{intrusive_adapter, key_adapter};
 /// use foyer_intrusive::core::adapter::{Adapter, KeyAdapter, Link};
 /// use foyer_intrusive::core::pointer::Pointer;
@@ -282,6 +286,8 @@ macro_rules! key_adapter {
 /// # Examples
 ///
 /// ```
+/// #![feature(offset_of)]
+///
 /// use foyer_intrusive::{intrusive_adapter, priority_adapter};
 /// use foyer_intrusive::core::adapter::{Adapter, PriorityAdapter, Link};
 /// use foyer_intrusive::core::pointer::Pointer;

--- a/foyer-intrusive/src/eviction/lfu.rs
+++ b/foyer-intrusive/src/eviction/lfu.rs
@@ -468,7 +468,7 @@ where
                     link
                 }
                 (Some(link_main), Some(link_tiny)) => {
-                    // Eviction from tiny or main depending on whether the tiny handle woould be
+                    // Eviction from tiny or main depending on whether the tiny handle would be
                     // admitted to main cachce. If it would be, evict from main cache, otherwise
                     // from tiny cache.
                     if self.lfu.admit_to_main(link_main.raw(), link_tiny.raw()) {

--- a/foyer-intrusive/src/lib.rs
+++ b/foyer-intrusive/src/lib.rs
@@ -27,6 +27,8 @@ pub use memoffset::offset_of;
 /// # Examples
 ///
 /// ```
+/// #![feature(offset_of)]
+///
 /// use foyer_intrusive::container_of;
 ///
 /// struct S { x: u32, y: u32 };

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -25,6 +25,7 @@ itertools = "0.12"
 libc = "0.2"
 parking_lot = "0.12"
 tokio = { workspace = true }
+
 [dev-dependencies]
 bytesize = "1"
 clap = { version = "4", features = ["derive"] }

--- a/foyer-memory/src/eviction/mod.rs
+++ b/foyer-memory/src/eviction/mod.rs
@@ -104,6 +104,7 @@ pub trait Eviction: Send + Sync + 'static {
 pub mod fifo;
 pub mod lfu;
 pub mod lru;
+pub mod s3fifo;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/foyer-memory/src/eviction/s3fifo.rs
+++ b/foyer-memory/src/eviction/s3fifo.rs
@@ -1,0 +1,258 @@
+use crate::CacheContext;
+use crate::Key;
+use crate::Value;
+use crate::handle::BaseHandle;
+use crate::handle::Handle;
+use crate::eviction::Eviction;
+use foyer_intrusive::collections::dlist::DlistLink;
+use foyer_intrusive::collections::dlist::Dlist;
+use std::ptr::NonNull;
+use std::fmt::Debug;
+use foyer_intrusive::intrusive_adapter;
+
+
+#[derive(Debug, Clone)]
+pub struct S3FifoContext;
+
+impl From<CacheContext> for S3FifoContext {
+    fn from(_: CacheContext) -> Self {
+        Self
+    }
+}
+
+impl From<S3FifoContext> for CacheContext {
+    fn from(_: S3FifoContext) -> Self {
+        CacheContext::Default
+    }
+}
+
+pub struct S3FifoHandle<K, V>
+where
+    K: Key,
+    V: Value,
+{
+    link: DlistLink,
+    count: i32,
+    base: BaseHandle<K, V, S3FifoContext>,
+}
+
+impl<K, V> Debug for S3FifoHandle<K, V>
+where
+    K: Key,
+    V: Value,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3FifoHandle").finish()
+    }
+}
+
+intrusive_adapter! { S3FifoHandleDlistAdapter<K, V> = NonNull<S3FifoHandle<K, V>>: S3FifoHandle<K, V> { link: DlistLink } where K: Key, V: Value }
+
+impl<K, V> S3FifoHandle<K, V>
+where
+    K: Key,
+    V: Value,
+{
+    pub fn inc (&mut self) {
+        if self.count >= 3 {
+            return;
+        }
+        self.count += 1;
+    }
+
+    pub fn dec (&mut self) {
+        if self.count <= 0 {
+            return;
+        }
+        self.count -= 1;
+    }
+}
+
+impl<K, V> Handle for S3FifoHandle<K, V>
+where
+    K: Key,
+    V: Value,
+{
+    type Key = K;
+    type Value = V;
+    type Context = S3FifoContext;
+
+    fn new() -> Self {
+        Self {
+            link: DlistLink::default(),
+            count: 0,
+            base: BaseHandle::new(),
+        }
+    }
+
+    fn init(&mut self, hash: u64, key: Self::Key, value: Self::Value, charge: usize, context: Self::Context) {
+        self.base.init(hash, key, value, charge, context);
+    }
+
+    fn base(&self) -> &BaseHandle<Self::Key, Self::Value, Self::Context> {
+        &self.base
+    }
+
+    fn base_mut(&mut self) -> &mut BaseHandle<Self::Key, Self::Value, Self::Context> {
+        &mut self.base
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct S3FifoConfig {}
+
+pub struct S3Fifo<K, V>
+where
+    K: Key,
+    V: Value,
+{
+    small_queue: Dlist<S3FifoHandleDlistAdapter<K, V>>,
+    main_queue: Dlist<S3FifoHandleDlistAdapter<K, V>>,
+    capacity: usize,
+    small_used: usize,
+    main_used: usize,
+}
+
+impl<K,V> S3Fifo<K,V>
+where
+    K: Key,
+    V: Value,
+{
+    unsafe fn evict(&mut self) -> Option<NonNull<<S3Fifo<K, V> as Eviction>::Handle>> {
+        if self.small_used > (0.1 * self.capacity as f64) as usize {
+            match self.evict_small() {
+                Some(ptr) => return Some(ptr),
+                None => return self.evict_main(),
+            }
+        } else {
+            return self.evict_main();
+        }
+    }
+
+    unsafe fn evict_small(&mut self) -> Option<NonNull<<S3Fifo<K, V> as Eviction>::Handle>>{
+        loop {
+            let ptr = self.small_queue.pop_front();
+            if ptr.is_none() {
+                return None;
+            }
+            let mut ptr = ptr.unwrap();
+            if ptr.as_mut().count > 1 {
+                self.main_queue.push_back(ptr);
+                self.small_used -= 1;
+                self.main_used += 1;
+            } else {
+                self.small_used -= 1;
+                return Some(ptr);
+            }
+        }
+    }
+
+    unsafe fn evict_main(&mut self) -> Option<NonNull<<S3Fifo<K, V> as Eviction>::Handle>>{
+       loop {
+            let ptr = self.main_queue.pop_front();
+            if ptr.is_none() {
+                return None;
+            }
+            let mut ptr = ptr.unwrap();
+            if ptr.as_mut().count > 0 {
+                self.main_queue.push_back(ptr);
+                ptr.as_mut().dec();
+            } else {
+                // evict
+                self.main_used -= 1;
+                return Some(ptr);
+            }
+       }
+    }
+}
+
+impl<K, V> Eviction for S3Fifo<K, V>
+where
+    K: Key,
+    V: Value,
+{
+    type Handle = S3FifoHandle<K, V>;
+    type Config = S3FifoConfig;
+
+    unsafe fn new(capacity: usize, _config: &Self::Config) -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            small_queue: Dlist::new(),
+            main_queue: Dlist::new(),
+            capacity,
+            small_used: 0,
+            main_used: 0,
+        }
+    }
+
+    unsafe fn push(&mut self, mut ptr: NonNull<Self::Handle>) {
+        self.small_queue.push_back(ptr);
+        self.small_used += 1;
+        ptr.as_mut().base_mut().set_in_eviction(true);
+    }
+
+    unsafe fn pop(&mut self) -> Option<NonNull<Self::Handle>> {
+        self.evict()
+    }
+
+    unsafe fn reinsert(&mut self, _: NonNull<Self::Handle>) {
+    }
+
+    unsafe fn access(&mut self, ptr: NonNull<Self::Handle>) {
+        let mut ptr = ptr;
+        ptr.as_mut().inc();
+    }
+
+    unsafe fn remove(&mut self, mut ptr: NonNull<Self::Handle>) {
+        let p = self.small_queue.iter_mut_from_raw(ptr.as_mut().link.raw()).remove();
+        if p.is_some() {
+            self.small_used -= 1;
+            assert_eq!(p.unwrap(), ptr);
+            ptr.as_mut().base_mut().set_in_eviction(false);
+            return;
+        }
+        let p = self.main_queue.iter_mut_from_raw(ptr.as_mut().link.raw()).remove();
+        if p.is_some() {
+            self.main_used -= 1;
+            assert_eq!(p.unwrap(), ptr);
+            ptr.as_mut().base_mut().set_in_eviction(false);
+            return;
+        }
+    }
+
+    unsafe fn clear(&mut self) -> Vec<NonNull<Self::Handle>> {
+        let mut res = Vec::with_capacity(self.len());
+        while let Some(mut ptr) = self.small_queue.pop_front() {
+            ptr.as_mut().base_mut().set_in_eviction(false);
+            res.push(ptr);
+        }
+        while let Some(mut ptr) = self.main_queue.pop_front() {
+            ptr.as_mut().base_mut().set_in_eviction(false);
+            res.push(ptr);
+        }
+        res
+    }
+
+    unsafe fn len(&self) -> usize {
+        self.small_queue.len() + self.main_queue.len()
+    }
+
+    unsafe fn is_empty(&self) -> bool {
+        self.small_queue.is_empty() && self.main_queue.is_empty()
+    }
+}
+
+unsafe impl<K, V> Send for S3Fifo<K, V>
+where
+    K: Key,
+    V: Value,
+{
+}
+unsafe impl<K, V> Sync for S3Fifo<K, V>
+where
+    K: Key,
+    V: Value,
+{
+}

--- a/foyer-memory/src/eviction/s3fifo.rs
+++ b/foyer-memory/src/eviction/s3fifo.rs
@@ -116,7 +116,7 @@ where
 
 #[derive(Debug, Clone)]
 pub struct S3FifoConfig {
-    small_queue_capacity_ratio: f64,
+    pub small_queue_capacity_ratio: f64,
 }
 
 pub struct S3Fifo<K, V>

--- a/foyer-memory/src/eviction/s3fifo.rs
+++ b/foyer-memory/src/eviction/s3fifo.rs
@@ -1,3 +1,17 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 use std::{fmt::Debug, ptr::NonNull};
 
 use foyer_intrusive::{

--- a/foyer-memory/src/prelude.rs
+++ b/foyer-memory/src/prelude.rs
@@ -13,9 +13,9 @@
 //  limitations under the License.
 
 pub use crate::{
-    cache::{Cache, CacheEntry, Entry, EntryState, FifoCacheConfig, LfuCacheConfig, LruCacheConfig},
+    cache::{Cache, CacheEntry, Entry, EntryState, FifoCacheConfig, LfuCacheConfig, LruCacheConfig, S3FifoCacheConfig},
     context::CacheContext,
-    eviction::{fifo::FifoConfig, lfu::LfuConfig, lru::LruConfig},
+    eviction::{fifo::FifoConfig, lfu::LfuConfig, lru::LruConfig, s3fifo::S3FifoConfig},
     listener::{CacheEventListener, DefaultCacheEventListener},
     metrics::Metrics,
 };

--- a/foyer-workspace-hack/Cargo.toml
+++ b/foyer-workspace-hack/Cargo.toml
@@ -28,6 +28,7 @@ futures-executor = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "channel", "io", "sink"] }
 hashbrown = { version = "0.14", features = ["raw"] }
+itertools = { version = "0.12" }
 libc = { version = "0.2", features = ["extra_traits"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "deadlock_detection"] }
 parking_lot_core = { version = "0.9", default-features = false, features = ["deadlock_detection"] }
@@ -39,6 +40,7 @@ tracing-core = { version = "0.1" }
 [build-dependencies]
 cc = { version = "1", default-features = false, features = ["parallel"] }
 either = { version = "1", default-features = false, features = ["use_std"] }
+itertools = { version = "0.12" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 syn = { version = "2", features = ["extra-traits", "full", "visit-mut"] }


### PR DESCRIPTION
## What's changed and what's your intention?

> This PR adds S3Fifo eviction policy based on https://blog.jasony.me/system/cache/2023/08/01/s3fifo and https://github.com/matrixorigin/matrixone/blob/c582b7d3ce8f7c177f2bd268a37375ae1a5b18bd/pkg/fileservice/fifocache/fifo.go#L24. It use a small queue and a main queue. The small queue is also served as the ghost queue. 

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
