### PR TITLE
fix: fix state() for s3fifo

### DIFF
--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -451,16 +451,22 @@ where
 {
     pub fn state(&self) -> EntryState {
         match self {
-            Entry::Fifo(FifoEntry::Hit(_)) | Entry::Lru(LruEntry::Hit(_)) | Entry::Lfu(LfuEntry::Hit(_)) => {
-                EntryState::Hit
-            }
-            Entry::Fifo(FifoEntry::Wait(_)) | Entry::Lru(LruEntry::Wait(_)) | Entry::Lfu(LfuEntry::Wait(_)) => {
-                EntryState::Wait
-            }
-            Entry::Fifo(FifoEntry::Miss(_)) | Entry::Lru(LruEntry::Miss(_)) | Entry::Lfu(LfuEntry::Miss(_)) => {
-                EntryState::Miss
-            }
-            _ => unreachable!(),
+            Entry::Fifo(FifoEntry::Hit(_))
+            | Entry::Lru(LruEntry::Hit(_))
+            | Entry::Lfu(LfuEntry::Hit(_))
+            | Entry::S3Fifo(S3FifoEntry::Hit(_)) => EntryState::Hit,
+            Entry::Fifo(FifoEntry::Wait(_))
+            | Entry::Lru(LruEntry::Wait(_))
+            | Entry::Lfu(LfuEntry::Wait(_))
+            | Entry::S3Fifo(S3FifoEntry::Wait(_)) => EntryState::Wait,
+            Entry::Fifo(FifoEntry::Miss(_))
+            | Entry::Lru(LruEntry::Miss(_))
+            | Entry::Lfu(LfuEntry::Miss(_))
+            | Entry::S3Fifo(S3FifoEntry::Miss(_)) => EntryState::Miss,
+            Entry::Fifo(FifoEntry::Invalid)
+            | Entry::Lru(LruEntry::Invalid)
+            | Entry::Lfu(LfuEntry::Invalid)
+            | Entry::S3Fifo(S3FifoEntry::Invalid) => unreachable!(),
         }
     }
 }

--- a/foyer-memory/src/lib.rs
+++ b/foyer-memory/src/lib.rs
@@ -65,7 +65,6 @@
 //! The handle that does not appear in either the indexer or the eviction container, and has no external owner, will be
 //! destroyed.
 
-#![feature(trait_alias)]
 #![feature(offset_of)]
 
 pub trait Key: Send + Sync + 'static + std::hash::Hash + Eq + Ord {}


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

`state()` on s3fifo entry will panic, this PR will fix it.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#303 