### PR TITLE
refactor: use generic type for cursor instead of associated type

### DIFF
--- a/foyer-common/src/lib.rs
+++ b/foyer-common/src/lib.rs
@@ -17,7 +17,6 @@
 #![feature(bound_map)]
 #![feature(associated_type_defaults)]
 #![feature(cfg_match)]
-#![feature(let_chains)]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub mod async_queue;

--- a/foyer-intrusive/src/lib.rs
+++ b/foyer-intrusive/src/lib.rs
@@ -12,7 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#![feature(associated_type_bounds)]
 #![feature(ptr_metadata)]
 #![feature(trait_alias)]
 #![feature(lint_reasons)]

--- a/foyer-storage/src/lib.rs
+++ b/foyer-storage/src/lib.rs
@@ -20,7 +20,6 @@
 #![feature(error_generic_member_access)]
 #![feature(lazy_cell)]
 #![feature(lint_reasons)]
-#![feature(associated_type_defaults)]
 #![feature(box_into_inner)]
 #![feature(try_trait_v2)]
 #![feature(offset_of)]


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)