### PR TITLE
chore: bump foyer to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2024-04-11
+
+| crate | version |
+| - | - |
+| foyer | 0.7.0 |
+| foyer-common | 0.5.0 |
+| foyer-intrusive | 0.4.0 |
+| foyer-memory | 0.2.0 |
+| foyer-storage | 0.6.0 |
+| foyer-storage-bench | 0.6.0 |
+| foyer-workspace-hack | 0.4.0 |
+
+<details>
+
+### Changes
+
+- Make `foyer` compatible with rust stable toolchain (MSRV = 1.77.2). 🎉
+
+</details>
+
 ## 2024-04-09
 
 | crate | version |
@@ -12,6 +32,8 @@
 - fix: Fix panics on `state()` for s3fifo entry.
 - fix: Enable `offset_of` feature for `foyer-storage`.
 
+</details>
+
 ## 2024-04-08
 
 | crate | version |
@@ -25,6 +47,8 @@
 
 - feat: Introduce s3fifo to `foyer-memory`.
 - fix: Fix doctest for `foyer-intrusive`.
+
+</details>
 
 ## 2024-03-21
 

--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foyer-common"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["MrCroxx <mrcroxx@outlook.com>"]
 description = "common utils for foyer - the hybrid cache for Rust"
@@ -17,7 +17,7 @@ normal = ["foyer-workspace-hack"]
 anyhow = "1.0"
 bytes = "1"
 cfg-if = "1"
-foyer-workspace-hack = { version = "0.3", path = "../foyer-workspace-hack" }
+foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }
 itertools = "0.12"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 paste = "1.0"

--- a/foyer-experimental-bench/Cargo.toml
+++ b/foyer-experimental-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foyer-experimental-bench"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 authors = ["MrCroxx <mrcroxx@outlook.com>"]
 description = "storage engine bench tool for foyer - the hybrid cache for Rust"
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mrcroxx/foyer"
 homepage = "https://github.com/mrcroxx/foyer"
 readme = "../README.md"
+publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 autobenches = false
 
@@ -19,11 +20,11 @@ anyhow = "1"
 bytesize = "1"
 clap = { version = "4", features = ["derive"] }
 console-subscriber = { version = "0.2", optional = true }
-foyer-common = { version = "0.4", path = "../foyer-common" }
-foyer-experimental = { version = "0.1", path = "../foyer-experimental" }
-foyer-intrusive = { version = "0.3", path = "../foyer-intrusive" }
-foyer-storage = { version = "0.5", path = "../foyer-storage" }
-foyer-workspace-hack = { version = "0.3", path = "../foyer-workspace-hack" }
+foyer-common = { version = "0.5", path = "../foyer-common" }
+foyer-experimental = { version = "*", path = "../foyer-experimental" }
+foyer-intrusive = { version = "0.4", path = "../foyer-intrusive" }
+foyer-storage = { version = "0.6", path = "../foyer-storage" }
+foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }
 futures = "0.3"
 hdrhistogram = "7"
 http-body-util = "0.1"

--- a/foyer-experimental/Cargo.toml
+++ b/foyer-experimental/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foyer-experimental"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 authors = ["MrCroxx <mrcroxx@outlook.com>"]
 description = "experimental components for foyer - the hybrid cache for Rust"
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mrcroxx/foyer"
 homepage = "https://github.com/mrcroxx/foyer"
 readme = "../README.md"
+publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [package.metadata.cargo-udeps.ignore]
@@ -17,8 +18,8 @@ normal = ["foyer-workspace-hack"]
 anyhow = "1.0"
 bytes = "1"
 crossbeam = { version = "0.8", features = ["std", "crossbeam-channel"] }
-foyer-common = { version = "0.4", path = "../foyer-common" }
-foyer-workspace-hack = { version = "0.3", path = "../foyer-workspace-hack" }
+foyer-common = { version = "0.5", path = "../foyer-common" }
+foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }
 lazy_static = "1"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 paste = "1.0"

--- a/foyer-intrusive/Cargo.toml
+++ b/foyer-intrusive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foyer-intrusive"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["MrCroxx <mrcroxx@outlook.com>"]
 description = "intrusive data structures for foyer - the hybrid cache for Rust"
@@ -16,8 +16,8 @@ normal = ["foyer-workspace-hack"]
 [dependencies]
 bytes = "1"
 cmsketch = "0.1"
-foyer-common = { version = "0.4", path = "../foyer-common" }
-foyer-workspace-hack = { version = "0.3", path = "../foyer-workspace-hack" }
+foyer-common = { version = "0.5", path = "../foyer-common" }
+foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }
 itertools = "0.12"
 memoffset = "0.9"
 parking_lot = "0.12"

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foyer-memory"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["MrCroxx <mrcroxx@outlook.com>"]
 description = "memory cache for foyer - the hybrid cache for Rust"
@@ -18,8 +18,8 @@ ahash = "0.8"
 bitflags = "2"
 cmsketch = "0.2"
 crossbeam = "0.8"
-foyer-intrusive = { version = "0.3", path = "../foyer-intrusive" }
-foyer-workspace-hack = { version = "0.3", path = "../foyer-workspace-hack" }
+foyer-intrusive = { version = "0.4", path = "../foyer-intrusive" }
+foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }
 futures = "0.3"
 hashbrown = "0.14"
 itertools = "0.12"

--- a/foyer-storage-bench/Cargo.toml
+++ b/foyer-storage-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foyer-storage-bench"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["MrCroxx <mrcroxx@outlook.com>"]
 description = "storage engine bench tool for foyer - the hybrid cache for Rust"
@@ -18,10 +18,10 @@ anyhow = "1"
 bytesize = "1"
 clap = { version = "4", features = ["derive"] }
 console-subscriber = { version = "0.2", optional = true }
-foyer-common = { version = "0.4", path = "../foyer-common" }
-foyer-intrusive = { version = "0.3", path = "../foyer-intrusive" }
-foyer-storage = { version = "0.5", path = "../foyer-storage" }
-foyer-workspace-hack = { version = "0.3", path = "../foyer-workspace-hack" }
+foyer-common = { version = "0.5", path = "../foyer-common" }
+foyer-intrusive = { version = "0.4", path = "../foyer-intrusive" }
+foyer-storage = { version = "0.6", path = "../foyer-storage" }
+foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }
 futures = "0.3"
 hdrhistogram = "7"
 http-body-util = "0.1"

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foyer-storage"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["MrCroxx <mrcroxx@outlook.com>"]
 description = "storage engine for foyer - the hybrid cache for Rust"
@@ -19,9 +19,9 @@ anyhow = "1.0"
 bitflags = "2.3.1"
 bitmaps = "3.2"
 bytes = "1"
-foyer-common = { version = "0.4", path = "../foyer-common" }
-foyer-intrusive = { version = "0.3", path = "../foyer-intrusive" }
-foyer-workspace-hack = { version = "0.3", path = "../foyer-workspace-hack" }
+foyer-common = { version = "0.5", path = "../foyer-common" }
+foyer-intrusive = { version = "0.4", path = "../foyer-intrusive" }
+foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }
 futures = "0.3"
 itertools = "0.12"
 lazy_static = "1"

--- a/foyer-workspace-hack/Cargo.toml
+++ b/foyer-workspace-hack/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "foyer-workspace-hack"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["MrCroxx <mrcroxx@outlook.com>"]
 description = "workspace-hack package, managed by hakari"
 license = "Apache-2.0"

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foyer"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["MrCroxx <mrcroxx@outlook.com>"]
 description = "Hybrid cache for Rust"
@@ -15,8 +15,8 @@ rust-version = "1.77.2"
 normal = ["foyer-workspace-hack"]
 
 [dependencies]
-foyer-common = { version = "0.4", path = "../foyer-common" }
-foyer-intrusive = { version = "0.3", path = "../foyer-intrusive" }
-foyer-memory = { version = "0.1", path = "../foyer-memory" }
-foyer-storage = { version = "0.5", path = "../foyer-storage" }
-foyer-workspace-hack = { version = "0.3", path = "../foyer-workspace-hack" }
+foyer-common = { version = "0.5", path = "../foyer-common" }
+foyer-intrusive = { version = "0.4", path = "../foyer-intrusive" }
+foyer-memory = { version = "0.2", path = "../foyer-memory" }
+foyer-storage = { version = "0.6", path = "../foyer-storage" }
+foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }


### PR DESCRIPTION
Signed-off-by: MrCroxx <mrcroxx@outlook.com>## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Make `foyer` compatible with rust stable toolchain (MSRV = 1.77.2). 🎉

| crate | version |
| - | - |
| foyer | 0.7.0 |
| foyer-common | 0.5.0 |
| foyer-intrusive | 0.4.0 |
| foyer-memory | 0.2.0 |
| foyer-storage | 0.6.0 |
| foyer-storage-bench | 0.6.0 |
| foyer-workspace-hack | 0.4.0 |

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#310 