### PR TITLE
refactor: loose query key bound for in-memory cache

### DIFF
--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -29,7 +29,7 @@ fn main() {
     });
 
     let entry = cache.insert("hello".to_string(), "world".to_string(), 1);
-    let e = cache.get(&"hello".to_string()).unwrap();
+    let e = cache.get("hello").unwrap();
 
     assert_eq!(entry.value(), e.value());
 }

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -12,7 +12,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::{hash::BuildHasher, ops::Deref, sync::Arc};
+use std::{
+    borrow::Borrow,
+    hash::{BuildHasher, Hash},
+    ops::Deref,
+    sync::Arc,
+};
 
 use ahash::RandomState;
 use futures::{Future, FutureExt};
@@ -293,7 +298,11 @@ where
         }
     }
 
-    pub fn remove(&self, key: &K) {
+    pub fn remove<Q>(&self, key: &Q)
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
         match self {
             Cache::Fifo(cache) => cache.remove(key),
             Cache::Lru(cache) => cache.remove(key),
@@ -302,7 +311,11 @@ where
         }
     }
 
-    pub fn get(&self, key: &K) -> Option<CacheEntry<K, V, L, S>> {
+    pub fn get<Q>(&self, key: &Q) -> Option<CacheEntry<K, V, L, S>>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
         match self {
             Cache::Fifo(cache) => cache.get(key).map(CacheEntry::from),
             Cache::Lru(cache) => cache.get(key).map(CacheEntry::from),


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

e.g.

```rust
pub fn get(&self, key: &K) -> Option<CacheEntry<K, V, L, S>>;
```

will be replaced with

```rust
unsafe fn get<Q>(&mut self, hash: u64, key: &Q) -> Option<NonNull<H>>
    where
        K: Borrow<Q>,
        Q: Hash + Eq + ?Sized;
```

to loose query key bound like:

```rust
let entry = cache.insert("hello".to_string(), "world".to_string(), 1);
let e = cache.get(&"hello".to_string()).unwrap();
```
can be rewritten with

```rust
let entry = cache.insert("hello".to_string(), "world".to_string(), 1);
let e = cache.get("hello").unwrap();
```

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
