### PR TITLE
refactor: loose bound of in-memory eviction related traits

### DIFF
--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -39,37 +39,40 @@ use crate::{
 };
 
 pub type FifoCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCache<K, V, Fifo<K, V>, HashTableIndexer<K, FifoHandle<K, V>>, L, S>;
-pub type FifoCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> = CacheConfig<Fifo<K, V>, L, S>;
+    GenericCache<K, V, Fifo<(K, V)>, HashTableIndexer<K, FifoHandle<(K, V)>>, L, S>;
+pub type FifoCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
+    CacheConfig<K, V, Fifo<(K, V)>, L, S>;
 pub type FifoCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCacheEntry<K, V, Fifo<K, V>, HashTableIndexer<K, FifoHandle<K, V>>, L, S>;
+    GenericCacheEntry<K, V, Fifo<(K, V)>, HashTableIndexer<K, FifoHandle<(K, V)>>, L, S>;
 pub type FifoEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericEntry<K, V, Fifo<K, V>, HashTableIndexer<K, FifoHandle<K, V>>, L, S, ER>;
+    GenericEntry<K, V, Fifo<(K, V)>, HashTableIndexer<K, FifoHandle<(K, V)>>, L, S, ER>;
 
 pub type LruCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCache<K, V, Lru<K, V>, HashTableIndexer<K, LruHandle<K, V>>, L, S>;
-pub type LruCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> = CacheConfig<Lru<K, V>, L, S>;
+    GenericCache<K, V, Lru<(K, V)>, HashTableIndexer<K, LruHandle<(K, V)>>, L, S>;
+pub type LruCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
+    CacheConfig<K, V, Lru<(K, V)>, L, S>;
 pub type LruCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCacheEntry<K, V, Lru<K, V>, HashTableIndexer<K, LruHandle<K, V>>, L, S>;
+    GenericCacheEntry<K, V, Lru<(K, V)>, HashTableIndexer<K, LruHandle<(K, V)>>, L, S>;
 pub type LruEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericEntry<K, V, Lru<K, V>, HashTableIndexer<K, LruHandle<K, V>>, L, S, ER>;
+    GenericEntry<K, V, Lru<(K, V)>, HashTableIndexer<K, LruHandle<(K, V)>>, L, S, ER>;
 
 pub type LfuCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCache<K, V, Lfu<K, V>, HashTableIndexer<K, LfuHandle<K, V>>, L, S>;
-pub type LfuCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> = CacheConfig<Lfu<K, V>, L, S>;
+    GenericCache<K, V, Lfu<(K, V)>, HashTableIndexer<K, LfuHandle<(K, V)>>, L, S>;
+pub type LfuCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
+    CacheConfig<K, V, Lfu<(K, V)>, L, S>;
 pub type LfuCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCacheEntry<K, V, Lfu<K, V>, HashTableIndexer<K, LfuHandle<K, V>>, L, S>;
+    GenericCacheEntry<K, V, Lfu<(K, V)>, HashTableIndexer<K, LfuHandle<(K, V)>>, L, S>;
 pub type LfuEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericEntry<K, V, Lfu<K, V>, HashTableIndexer<K, LfuHandle<K, V>>, L, S, ER>;
+    GenericEntry<K, V, Lfu<(K, V)>, HashTableIndexer<K, LfuHandle<(K, V)>>, L, S, ER>;
 
 pub type S3FifoCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCache<K, V, S3Fifo<K, V>, HashTableIndexer<K, S3FifoHandle<K, V>>, L, S>;
+    GenericCache<K, V, S3Fifo<(K, V)>, HashTableIndexer<K, S3FifoHandle<(K, V)>>, L, S>;
 pub type S3FifoCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    CacheConfig<S3Fifo<K, V>, L, S>;
+    CacheConfig<K, V, S3Fifo<(K, V)>, L, S>;
 pub type S3FifoCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCacheEntry<K, V, S3Fifo<K, V>, HashTableIndexer<K, S3FifoHandle<K, V>>, L, S>;
+    GenericCacheEntry<K, V, S3Fifo<(K, V)>, HashTableIndexer<K, S3FifoHandle<(K, V)>>, L, S>;
 pub type S3FifoEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericEntry<K, V, S3Fifo<K, V>, HashTableIndexer<K, S3FifoHandle<K, V>>, L, S, ER>;
+    GenericEntry<K, V, S3Fifo<(K, V)>, HashTableIndexer<K, S3FifoHandle<(K, V)>>, L, S, ER>;
 
 pub enum CacheEntry<K, V, L, S = RandomState>
 where

--- a/foyer-memory/src/eviction/lru.rs
+++ b/foyer-memory/src/eviction/lru.rs
@@ -163,7 +163,7 @@ where
     K: Key,
     V: Value,
 {
-    type Handle = LruHandle<K, V>;
+    type Item = LruHandle<K, V>;
     type Config = LruConfig;
 
     unsafe fn new(capacity: usize, config: &Self::Config) -> Self
@@ -186,7 +186,7 @@ where
         }
     }
 
-    unsafe fn push(&mut self, mut ptr: NonNull<Self::Handle>) {
+    unsafe fn push(&mut self, mut ptr: NonNull<Self::Item>) {
         let handle = ptr.as_mut();
 
         debug_assert!(!handle.link.is_linked());
@@ -208,7 +208,7 @@ where
         handle.base_mut().set_in_eviction(true);
     }
 
-    unsafe fn pop(&mut self) -> Option<NonNull<Self::Handle>> {
+    unsafe fn pop(&mut self) -> Option<NonNull<Self::Item>> {
         let mut ptr = self.list.pop_front().or_else(|| self.high_priority_list.pop_front())?;
 
         let handle = ptr.as_mut();
@@ -223,9 +223,9 @@ where
         Some(ptr)
     }
 
-    unsafe fn access(&mut self, _: NonNull<Self::Handle>) {}
+    unsafe fn access(&mut self, _: NonNull<Self::Item>) {}
 
-    unsafe fn reinsert(&mut self, mut ptr: NonNull<Self::Handle>) {
+    unsafe fn reinsert(&mut self, mut ptr: NonNull<Self::Item>) {
         let handle = ptr.as_mut();
 
         if handle.base().is_in_eviction() {
@@ -238,7 +238,7 @@ where
         }
     }
 
-    unsafe fn remove(&mut self, mut ptr: NonNull<Self::Handle>) {
+    unsafe fn remove(&mut self, mut ptr: NonNull<Self::Item>) {
         let handle = ptr.as_mut();
         debug_assert!(handle.link.is_linked());
 
@@ -252,7 +252,7 @@ where
         handle.base_mut().set_in_eviction(false);
     }
 
-    unsafe fn clear(&mut self) -> Vec<NonNull<Self::Handle>> {
+    unsafe fn clear(&mut self) -> Vec<NonNull<Self::Item>> {
         let mut res = Vec::with_capacity(self.len());
 
         while !self.list.is_empty() {
@@ -309,7 +309,7 @@ pub mod tests {
         K: Key + Clone,
         V: Value + Clone,
     {
-        fn dump(&self) -> Vec<(<Self::Handle as Handle>::Key, <Self::Handle as Handle>::Value)> {
+        fn dump(&self) -> Vec<(<Self::Item as Handle>::Key, <Self::Item as Handle>::Value)> {
             self.list
                 .iter()
                 .chain(self.high_priority_list.iter())

--- a/foyer-memory/src/eviction/mod.rs
+++ b/foyer-memory/src/eviction/mod.rs
@@ -14,13 +14,11 @@
 
 use std::ptr::NonNull;
 
-use crate::handle::Handle;
-
 /// The lifetime of `handle: Self::H` is managed by [`Indexer`].
 ///
 /// Each `handle`'s lifetime in [`Indexer`] must outlive the raw pointer in [`Eviction`].
 pub trait Eviction: Send + Sync + 'static {
-    type Handle: Handle;
+    type Item;
     type Config;
 
     /// Create a new empty eviction container.
@@ -39,7 +37,7 @@ pub trait Eviction: Send + Sync + 'static {
     /// The `ptr` must be kept holding until `pop` or `remove`.
     ///
     /// The base handle associated to the `ptr` must be set in cache.
-    unsafe fn push(&mut self, ptr: NonNull<Self::Handle>);
+    unsafe fn push(&mut self, ptr: NonNull<Self::Item>);
 
     /// Pop a handle `ptr` from the eviction container.
     ///
@@ -49,7 +47,7 @@ pub trait Eviction: Send + Sync + 'static {
     /// Or it may become dangling and cause UB.
     ///
     /// The base handle associated to the `ptr` must be set NOT in cache.
-    unsafe fn pop(&mut self) -> Option<NonNull<Self::Handle>>;
+    unsafe fn pop(&mut self) -> Option<NonNull<Self::Item>>;
 
     /// Try to reinsert a handle `ptr` into the eviction container after access.
     ///
@@ -60,7 +58,7 @@ pub trait Eviction: Send + Sync + 'static {
     /// The given `ptr` may be either IN or NOT IN the eviction container.
     /// If the `ptr` is reinserted, the base handle associated to it must be set in cache.
     /// If the `ptr` is NOT reinserted, the base handle associated to it must be set NOT in cache.
-    unsafe fn reinsert(&mut self, ptr: NonNull<Self::Handle>);
+    unsafe fn reinsert(&mut self, ptr: NonNull<Self::Item>);
 
     /// Notify the eviciton container that the `ptr` is accessed.
     /// The eviction container can update its statistics.
@@ -68,7 +66,7 @@ pub trait Eviction: Send + Sync + 'static {
     /// # Safety
     ///
     /// The given `ptr` can be EITHER in the eviction container OR not in the eviction container.
-    unsafe fn access(&mut self, ptr: NonNull<Self::Handle>);
+    unsafe fn access(&mut self, ptr: NonNull<Self::Item>);
 
     /// Remove the given `ptr` from the eviction container.
     ///
@@ -79,7 +77,7 @@ pub trait Eviction: Send + Sync + 'static {
     /// The `ptr` must be taken from the eviction container, otherwise it may become dangling and cause UB.
     ///
     /// The base handle associated to the `ptr` must be set NOT in cache.
-    unsafe fn remove(&mut self, ptr: NonNull<Self::Handle>);
+    unsafe fn remove(&mut self, ptr: NonNull<Self::Item>);
 
     /// Remove all `ptr`s from the eviction container and reset.
     ///
@@ -88,7 +86,7 @@ pub trait Eviction: Send + Sync + 'static {
     /// All `ptr` must be taken from the eviction container, otherwise it may become dangling and cause UB.
     ///
     /// All base handles associated to the `ptr`s must be set NOT in cache.
-    unsafe fn clear(&mut self) -> Vec<NonNull<Self::Handle>>;
+    unsafe fn clear(&mut self) -> Vec<NonNull<Self::Item>>;
 
     /// Return the count of the `ptr`s that in the eviction container.
     ///

--- a/foyer-memory/src/eviction/s3fifo.rs
+++ b/foyer-memory/src/eviction/s3fifo.rs
@@ -22,7 +22,7 @@ use foyer_intrusive::{
 use crate::{
     eviction::Eviction,
     handle::{BaseHandle, Handle},
-    CacheContext, Key, Value,
+    CacheContext,
 };
 
 #[derive(Debug, Clone)]
@@ -46,33 +46,30 @@ enum Queue {
     Small,
 }
 
-pub struct S3FifoHandle<K, V>
+pub struct S3FifoHandle<T>
 where
-    K: Key,
-    V: Value,
+    T: Send + Sync + 'static,
 {
     link: DlistLink,
-    base: BaseHandle<K, V, S3FifoContext>,
+    base: BaseHandle<T, S3FifoContext>,
     freq: u8,
     queue: Queue,
 }
 
-impl<K, V> Debug for S3FifoHandle<K, V>
+impl<T> Debug for S3FifoHandle<T>
 where
-    K: Key,
-    V: Value,
+    T: Send + Sync + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("S3FifoHandle").finish()
     }
 }
 
-intrusive_adapter! { S3FifoHandleDlistAdapter<K, V> = NonNull<S3FifoHandle<K, V>>: S3FifoHandle<K, V> { link: DlistLink } where K: Key, V: Value }
+intrusive_adapter! { S3FifoHandleDlistAdapter<T> = NonNull<S3FifoHandle<T>>: S3FifoHandle<T> { link: DlistLink } where T: Send + Sync + 'static }
 
-impl<K, V> S3FifoHandle<K, V>
+impl<T> S3FifoHandle<T>
 where
-    K: Key,
-    V: Value,
+    T: Send + Sync + 'static,
 {
     #[inline(always)]
     pub fn inc(&mut self) {
@@ -90,13 +87,11 @@ where
     }
 }
 
-impl<K, V> Handle for S3FifoHandle<K, V>
+impl<T> Handle for S3FifoHandle<T>
 where
-    K: Key,
-    V: Value,
+    T: Send + Sync + 'static,
 {
-    type Key = K;
-    type Value = V;
+    type Data = T;
     type Context = S3FifoContext;
 
     fn new() -> Self {
@@ -108,15 +103,15 @@ where
         }
     }
 
-    fn init(&mut self, hash: u64, key: Self::Key, value: Self::Value, charge: usize, context: Self::Context) {
-        self.base.init(hash, key, value, charge, context);
+    fn init(&mut self, hash: u64, data: Self::Data, charge: usize, context: Self::Context) {
+        self.base.init(hash, data, charge, context);
     }
 
-    fn base(&self) -> &BaseHandle<Self::Key, Self::Value, Self::Context> {
+    fn base(&self) -> &BaseHandle<Self::Data, Self::Context> {
         &self.base
     }
 
-    fn base_mut(&mut self) -> &mut BaseHandle<Self::Key, Self::Value, Self::Context> {
+    fn base_mut(&mut self) -> &mut BaseHandle<Self::Data, Self::Context> {
         &mut self.base
     }
 }
@@ -126,13 +121,12 @@ pub struct S3FifoConfig {
     pub small_queue_capacity_ratio: f64,
 }
 
-pub struct S3Fifo<K, V>
+pub struct S3Fifo<T>
 where
-    K: Key,
-    V: Value,
+    T: Send + Sync + 'static,
 {
-    small_queue: Dlist<S3FifoHandleDlistAdapter<K, V>>,
-    main_queue: Dlist<S3FifoHandleDlistAdapter<K, V>>,
+    small_queue: Dlist<S3FifoHandleDlistAdapter<T>>,
+    main_queue: Dlist<S3FifoHandleDlistAdapter<T>>,
 
     small_capacity: usize,
 
@@ -140,12 +134,11 @@ where
     main_charges: usize,
 }
 
-impl<K, V> S3Fifo<K, V>
+impl<T> S3Fifo<T>
 where
-    K: Key,
-    V: Value,
+    T: Send + Sync + 'static,
 {
-    unsafe fn evict(&mut self) -> Option<NonNull<<S3Fifo<K, V> as Eviction>::Item>> {
+    unsafe fn evict(&mut self) -> Option<NonNull<S3FifoHandle<T>>> {
         // TODO(MrCroxx): Use `let_chains` here after it is stable.
         if self.small_charges > self.small_capacity {
             if let Some(ptr) = self.evict_small() {
@@ -155,7 +148,7 @@ where
         self.evict_main()
     }
 
-    unsafe fn evict_small(&mut self) -> Option<NonNull<<S3Fifo<K, V> as Eviction>::Item>> {
+    unsafe fn evict_small(&mut self) -> Option<NonNull<S3FifoHandle<T>>> {
         while let Some(mut ptr) = self.small_queue.pop_front() {
             let handle = ptr.as_mut();
             if handle.freq > 1 {
@@ -173,7 +166,7 @@ where
         None
     }
 
-    unsafe fn evict_main(&mut self) -> Option<NonNull<<S3Fifo<K, V> as Eviction>::Item>> {
+    unsafe fn evict_main(&mut self) -> Option<NonNull<S3FifoHandle<T>>> {
         while let Some(mut ptr) = self.main_queue.pop_front() {
             let handle = ptr.as_mut();
             if handle.freq > 0 {
@@ -189,12 +182,11 @@ where
     }
 }
 
-impl<K, V> Eviction for S3Fifo<K, V>
+impl<T> Eviction for S3Fifo<T>
 where
-    K: Key,
-    V: Value,
+    T: Send + Sync + 'static,
 {
-    type Item = S3FifoHandle<K, V>;
+    type Item = S3FifoHandle<T>;
     type Config = S3FifoConfig;
 
     unsafe fn new(capacity: usize, config: &Self::Config) -> Self
@@ -300,18 +292,8 @@ where
     }
 }
 
-unsafe impl<K, V> Send for S3Fifo<K, V>
-where
-    K: Key,
-    V: Value,
-{
-}
-unsafe impl<K, V> Sync for S3Fifo<K, V>
-where
-    K: Key,
-    V: Value,
-{
-}
+unsafe impl<T> Send for S3Fifo<T> where T: Send + Sync + 'static {}
+unsafe impl<T> Sync for S3Fifo<T> where T: Send + Sync + 'static {}
 
 #[cfg(test)]
 mod tests {
@@ -322,32 +304,24 @@ mod tests {
     use super::*;
     use crate::eviction::test_utils::TestEviction;
 
-    impl<K, V> TestEviction for S3Fifo<K, V>
+    impl<T> TestEviction for S3Fifo<T>
     where
-        K: Key + Clone,
-        V: Value + Clone,
+        T: Send + Sync + 'static + Clone,
     {
-        fn dump(&self) -> Vec<(<Self::Item as Handle>::Key, <Self::Item as Handle>::Value)> {
+        fn dump(&self) -> Vec<T> {
             self.small_queue
                 .iter()
                 .chain(self.main_queue.iter())
-                .map(|handle| (handle.base().key().clone(), handle.base().value().clone()))
+                .map(|handle| handle.base().data_unwrap_unchecked().clone())
                 .collect_vec()
         }
     }
 
-    type TestS3Fifo = S3Fifo<u64, u64>;
-    type TestS3FifoHandle = S3FifoHandle<u64, u64>;
+    type TestS3Fifo = S3Fifo<u64>;
+    type TestS3FifoHandle = S3FifoHandle<u64>;
 
     fn assert_test_s3fifo(s3fifo: &TestS3Fifo, small: Vec<u64>, main: Vec<u64>) {
-        let mut s = s3fifo
-            .dump()
-            .into_iter()
-            .map(|(k, v)| {
-                assert_eq!(k, v);
-                k
-            })
-            .collect_vec();
+        let mut s = s3fifo.dump().into_iter().collect_vec();
         assert_eq!(s.len(), s3fifo.small_queue.len() + s3fifo.main_queue.len());
         let m = s.split_off(s3fifo.small_queue.len());
         assert_eq!((&s, &m), (&small, &main));
@@ -366,7 +340,7 @@ mod tests {
             let ptrs = (0..100)
                 .map(|i| {
                     let mut handle = Box::new(TestS3FifoHandle::new());
-                    handle.init(i, i, i, 1, S3FifoContext);
+                    handle.init(i, i, 1, S3FifoContext);
                     NonNull::new_unchecked(Box::into_raw(handle))
                 })
                 .collect_vec();

--- a/foyer-memory/src/eviction/test_utils.rs
+++ b/foyer-memory/src/eviction/test_utils.rs
@@ -17,6 +17,9 @@ use crate::handle::Handle;
 
 // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
 #[allow(clippy::type_complexity)]
-pub trait TestEviction: Eviction {
-    fn dump(&self) -> Vec<(<Self::Handle as Handle>::Key, <Self::Handle as Handle>::Value)>;
+pub trait TestEviction: Eviction
+where
+    Self::Item: Handle,
+{
+    fn dump(&self) -> Vec<(<Self::Item as Handle>::Key, <Self::Item as Handle>::Value)>;
 }

--- a/foyer-memory/src/eviction/test_utils.rs
+++ b/foyer-memory/src/eviction/test_utils.rs
@@ -21,5 +21,5 @@ pub trait TestEviction: Eviction
 where
     Self::Item: Handle,
 {
-    fn dump(&self) -> Vec<(<Self::Item as Handle>::Key, <Self::Item as Handle>::Value)>;
+    fn dump(&self) -> Vec<<Self::Item as Handle>::Data>;
 }

--- a/foyer-memory/src/indexer.rs
+++ b/foyer-memory/src/indexer.rs
@@ -18,6 +18,25 @@ use hashbrown::hash_table::{Entry as HashTableEntry, HashTable};
 
 use crate::{handle::Handle, Key};
 
+pub trait IndexerV2<K, T>: Send + Sync + 'static {
+    fn key(item: &T) -> &K;
+    fn key_mut(item: &mut T) -> &mut K;
+
+    fn new() -> Self;
+    unsafe fn insert(&mut self, item: T) -> Option<T>;
+    unsafe fn get<Q>(&self, hash: u64, key: &Q) -> Option<&T>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized;
+    unsafe fn remove<Q>(&mut self, hash: u64, key: &Q) -> Option<T>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized;
+    unsafe fn drain(&mut self) -> impl Iterator<Item = T>;
+}
+
+// impl<K, T> IndexerV2<K, T> for HashTable<> {}
+
 pub trait Indexer: Send + Sync + 'static {
     type Key: Key;
     type Handle: Handle<Key = Self::Key>;


### PR DESCRIPTION
Signed-off-by: MrCroxx <mrcroxx@outlook.com>## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

The eviction containers do not rely on `Key` or `Value`. The trait bounds can be lost. 

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#329 