### PR TITLE
feat: introduce eviction queue abstraction

### DIFF
--- a/foyer-memory/src/eviction/lfu.rs
+++ b/foyer-memory/src/eviction/lfu.rs
@@ -190,7 +190,7 @@ impl<T> Eviction for Lfu<T>
 where
     T: Send + Sync + 'static,
 {
-    type Item = LfuHandle<T>;
+    type Handle = LfuHandle<T>;
     type Config = LfuConfig;
 
     unsafe fn new(capacity: usize, config: &Self::Config) -> Self
@@ -235,7 +235,7 @@ where
         }
     }
 
-    unsafe fn push(&mut self, mut ptr: NonNull<Self::Item>) {
+    unsafe fn push(&mut self, mut ptr: NonNull<Self::Handle>) {
         let handle = ptr.as_mut();
 
         debug_assert!(!handle.link.is_linked());
@@ -261,7 +261,7 @@ where
         }
     }
 
-    unsafe fn pop(&mut self) -> Option<NonNull<Self::Item>> {
+    unsafe fn pop(&mut self) -> Option<NonNull<Self::Handle>> {
         // Compare the frequency of the front element of `window` and `probation` queue, and evict the lower one.
         // If both `window` and `probation` are empty, try evict from `protected`.
         let mut ptr = match (self.window.front(), self.probation.front()) {
@@ -295,7 +295,7 @@ where
         Some(ptr)
     }
 
-    unsafe fn reinsert(&mut self, mut ptr: NonNull<Self::Item>) {
+    unsafe fn reinsert(&mut self, mut ptr: NonNull<Self::Handle>) {
         let handle = ptr.as_mut();
 
         match handle.queue {
@@ -344,11 +344,11 @@ where
         }
     }
 
-    unsafe fn access(&mut self, ptr: NonNull<Self::Item>) {
+    unsafe fn access(&mut self, ptr: NonNull<Self::Handle>) {
         self.update_frequencies(ptr.as_ref().base().hash());
     }
 
-    unsafe fn remove(&mut self, mut ptr: NonNull<Self::Item>) {
+    unsafe fn remove(&mut self, mut ptr: NonNull<Self::Handle>) {
         let handle = ptr.as_mut();
 
         debug_assert!(handle.link.is_linked());
@@ -369,7 +369,7 @@ where
         handle.base_mut().set_in_eviction(false);
     }
 
-    unsafe fn clear(&mut self) -> Vec<NonNull<Self::Item>> {
+    unsafe fn clear(&mut self) -> Vec<NonNull<Self::Handle>> {
         let mut res = Vec::with_capacity(self.len());
 
         while !self.is_empty() {
@@ -383,11 +383,11 @@ where
         res
     }
 
-    unsafe fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.window.len() + self.probation.len() + self.protected.len()
     }
 
-    unsafe fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }

--- a/foyer-memory/src/eviction/lru.rs
+++ b/foyer-memory/src/eviction/lru.rs
@@ -146,7 +146,7 @@ impl<T> Eviction for Lru<T>
 where
     T: Send + Sync + 'static,
 {
-    type Item = LruHandle<T>;
+    type Handle = LruHandle<T>;
     type Config = LruConfig;
 
     unsafe fn new(capacity: usize, config: &Self::Config) -> Self
@@ -169,7 +169,7 @@ where
         }
     }
 
-    unsafe fn push(&mut self, mut ptr: NonNull<Self::Item>) {
+    unsafe fn push(&mut self, mut ptr: NonNull<Self::Handle>) {
         let handle = ptr.as_mut();
 
         debug_assert!(!handle.link.is_linked());
@@ -191,7 +191,7 @@ where
         handle.base_mut().set_in_eviction(true);
     }
 
-    unsafe fn pop(&mut self) -> Option<NonNull<Self::Item>> {
+    unsafe fn pop(&mut self) -> Option<NonNull<Self::Handle>> {
         let mut ptr = self.list.pop_front().or_else(|| self.high_priority_list.pop_front())?;
 
         let handle = ptr.as_mut();
@@ -206,9 +206,9 @@ where
         Some(ptr)
     }
 
-    unsafe fn access(&mut self, _: NonNull<Self::Item>) {}
+    unsafe fn access(&mut self, _: NonNull<Self::Handle>) {}
 
-    unsafe fn reinsert(&mut self, mut ptr: NonNull<Self::Item>) {
+    unsafe fn reinsert(&mut self, mut ptr: NonNull<Self::Handle>) {
         let handle = ptr.as_mut();
 
         if handle.base().is_in_eviction() {
@@ -221,7 +221,7 @@ where
         }
     }
 
-    unsafe fn remove(&mut self, mut ptr: NonNull<Self::Item>) {
+    unsafe fn remove(&mut self, mut ptr: NonNull<Self::Handle>) {
         let handle = ptr.as_mut();
         debug_assert!(handle.link.is_linked());
 
@@ -235,7 +235,7 @@ where
         handle.base_mut().set_in_eviction(false);
     }
 
-    unsafe fn clear(&mut self) -> Vec<NonNull<Self::Item>> {
+    unsafe fn clear(&mut self) -> Vec<NonNull<Self::Handle>> {
         let mut res = Vec::with_capacity(self.len());
 
         while !self.list.is_empty() {
@@ -256,11 +256,11 @@ where
         res
     }
 
-    unsafe fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.high_priority_list.len() + self.list.len()
     }
 
-    unsafe fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }

--- a/foyer-memory/src/eviction/queue.rs
+++ b/foyer-memory/src/eviction/queue.rs
@@ -1,0 +1,92 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::ptr::NonNull;
+
+use crate::{handle::Handle, CacheContext};
+
+use super::{fifo::Fifo, lfu::Lfu, lru::Lru, s3fifo::S3Fifo, Eviction};
+
+pub struct EvictionQueue<T, E>
+where
+    E: Eviction,
+    E::Handle: Handle<Data = T>,
+{
+    eviction: E,
+}
+
+impl<T, E> EvictionQueue<T, E>
+where
+    E: Eviction,
+    E::Handle: Handle<Data = T>,
+{
+    pub fn new(capacity: usize, config: &E::Config) -> Self {
+        let eviction = unsafe { E::new(capacity, config) };
+        Self { eviction }
+    }
+
+    pub fn push(&mut self, data: <E::Handle as Handle>::Data) {
+        self.push_with_context(data, CacheContext::default().into())
+    }
+
+    pub fn push_with_context(&mut self, data: <E::Handle as Handle>::Data, context: <E::Handle as Handle>::Context) {
+        unsafe {
+            let mut handle = Box::new(<E::Handle as Handle>::new());
+            handle.init(0, data, 0, context);
+            let ptr = NonNull::new_unchecked(Box::into_raw(handle));
+            self.eviction.push(ptr)
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<<E::Handle as Handle>::Data> {
+        self.pop_with_context().map(|(data, _)| data)
+    }
+
+    // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
+    #[allow(clippy::type_complexity)]
+    pub fn pop_with_context(&mut self) -> Option<(<E::Handle as Handle>::Data, <E::Handle as Handle>::Context)> {
+        unsafe {
+            let mut ptr = self.eviction.pop()?;
+            let (data, context, _) = ptr.as_mut().base_mut().take();
+            Some((data, context))
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.eviction.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.eviction.is_empty()
+    }
+}
+
+pub type FifoQueue<T> = EvictionQueue<T, Fifo<T>>;
+pub type LruQueue<T> = EvictionQueue<T, Lru<T>>;
+pub type LfuQueue<T> = EvictionQueue<T, Lfu<T>>;
+pub type S3FifoQueue<T> = EvictionQueue<T, S3Fifo<T>>;
+
+#[cfg(test)]
+mod tests {
+    use crate::FifoConfig;
+
+    use super::*;
+
+    #[test]
+    fn test_eviction_queue() {
+        let mut fifo = FifoQueue::new(100, &FifoConfig {});
+        (0..100).for_each(|i| fifo.push(i));
+        (0..100).for_each(|i| assert_eq!(fifo.pop(), Some(i)));
+    }
+}

--- a/foyer-memory/src/eviction/queue.rs
+++ b/foyer-memory/src/eviction/queue.rs
@@ -72,6 +72,16 @@ where
     }
 }
 
+impl<T, E> Drop for EvictionQueue<T, E>
+where
+    E: Eviction,
+    E::Handle: Handle<Data = T>,
+{
+    fn drop(&mut self) {
+        unsafe { self.eviction.clear() };
+    }
+}
+
 pub type FifoQueue<T> = EvictionQueue<T, Fifo<T>>;
 pub type LruQueue<T> = EvictionQueue<T, Lru<T>>;
 pub type LfuQueue<T> = EvictionQueue<T, Lfu<T>>;

--- a/foyer-memory/src/eviction/test_utils.rs
+++ b/foyer-memory/src/eviction/test_utils.rs
@@ -19,7 +19,7 @@ use crate::handle::Handle;
 #[allow(clippy::type_complexity)]
 pub trait TestEviction: Eviction
 where
-    Self::Item: Handle,
+    Self::Handle: Handle,
 {
-    fn dump(&self) -> Vec<<Self::Item as Handle>::Data>;
+    fn dump(&self) -> Vec<<Self::Handle as Handle>::Data>;
 }

--- a/foyer-memory/src/prelude.rs
+++ b/foyer-memory/src/prelude.rs
@@ -15,7 +15,13 @@
 pub use crate::{
     cache::{Cache, CacheEntry, Entry, EntryState, FifoCacheConfig, LfuCacheConfig, LruCacheConfig, S3FifoCacheConfig},
     context::CacheContext,
-    eviction::{fifo::FifoConfig, lfu::LfuConfig, lru::LruConfig, s3fifo::S3FifoConfig},
+    eviction::{
+        fifo::FifoConfig,
+        lfu::LfuConfig,
+        lru::LruConfig,
+        queue::{FifoQueue, LfuQueue, LruQueue, S3FifoQueue},
+        s3fifo::S3FifoConfig,
+    },
     listener::{CacheEventListener, DefaultCacheEventListener},
     metrics::Metrics,
 };


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Introduce eviction queue abstraction, export aliased types:

```rust
pub type FifoQueue<T> = EvictionQueue<T, Fifo<T>>;
pub type LruQueue<T> = EvictionQueue<T, Lru<T>>;
pub type LfuQueue<T> = EvictionQueue<T, Lfu<T>>;
pub type S3FifoQueue<T> = EvictionQueue<T, S3Fifo<T>>;
```

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#329 