### PR TITLE
feat: introduce `CacheBuilder` for in-memory cache

### DIFF
--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -12,24 +12,18 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::hash::RandomState;
-
-use foyer::memory::{Cache, DefaultCacheEventListener, LruCacheConfig, LruConfig};
+use foyer::memory::{CacheBuilder, LruConfig};
 
 fn main() {
-    let cache = Cache::new(
-        LruCacheConfig {
-            capacity: 16,
-            shards: 4,
-            eviction_config: LruConfig {
+    let cache = CacheBuilder::new(16)
+        .with_shards(4)
+        .with_eviction_config(
+            LruConfig {
                 high_priority_pool_ratio: 0.1,
-            },
-            object_pool_capacity: 1024,
-            hash_builder: RandomState::default(),
-            event_listener: DefaultCacheEventListener::default(),
-        }
-        .into(),
-    );
+            }
+            .into(),
+        )
+        .build();
 
     let entry = cache.insert("hello".to_string(), "world".to_string(), 1);
     let e = cache.get("hello").unwrap();

--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -17,12 +17,9 @@ use foyer::memory::{CacheBuilder, LruConfig};
 fn main() {
     let cache = CacheBuilder::new(16)
         .with_shards(4)
-        .with_eviction_config(
-            LruConfig {
-                high_priority_pool_ratio: 0.1,
-            }
-            .into(),
-        )
+        .with_eviction_config(LruConfig {
+            high_priority_pool_ratio: 0.1,
+        })
         .build();
 
     let entry = cache.insert("hello".to_string(), "world".to_string(), 1);

--- a/foyer-memory/benches/bench_hit_ratio.rs
+++ b/foyer-memory/benches/bench_hit_ratio.rs
@@ -85,7 +85,7 @@ fn moka_cache_hit(cache: &moka::sync::Cache<CacheKey, CacheValue>, keys: &[Strin
 fn new_fifo_cache(capacity: usize) -> Cache<CacheKey, CacheValue> {
     CacheBuilder::new(capacity)
         .with_shards(SHARDS)
-        .with_eviction_config(FifoConfig {}.into())
+        .with_eviction_config(FifoConfig {})
         .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
         .build()
 }
@@ -93,12 +93,9 @@ fn new_fifo_cache(capacity: usize) -> Cache<CacheKey, CacheValue> {
 fn new_lru_cache(capacity: usize) -> Cache<CacheKey, CacheValue> {
     CacheBuilder::new(capacity)
         .with_shards(SHARDS)
-        .with_eviction_config(
-            LruConfig {
-                high_priority_pool_ratio: 0.1,
-            }
-            .into(),
-        )
+        .with_eviction_config(LruConfig {
+            high_priority_pool_ratio: 0.1,
+        })
         .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
         .build()
 }
@@ -106,15 +103,12 @@ fn new_lru_cache(capacity: usize) -> Cache<CacheKey, CacheValue> {
 fn new_lfu_cache(capacity: usize) -> Cache<CacheKey, CacheValue> {
     CacheBuilder::new(capacity)
         .with_shards(SHARDS)
-        .with_eviction_config(
-            LfuConfig {
-                window_capacity_ratio: 0.1,
-                protected_capacity_ratio: 0.8,
-                cmsketch_eps: 0.001,
-                cmsketch_confidence: 0.9,
-            }
-            .into(),
-        )
+        .with_eviction_config(LfuConfig {
+            window_capacity_ratio: 0.1,
+            protected_capacity_ratio: 0.8,
+            cmsketch_eps: 0.001,
+            cmsketch_confidence: 0.9,
+        })
         .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
         .build()
 }
@@ -122,12 +116,9 @@ fn new_lfu_cache(capacity: usize) -> Cache<CacheKey, CacheValue> {
 fn new_s3fifo_cache(capacity: usize) -> Cache<CacheKey, CacheValue> {
     CacheBuilder::new(capacity)
         .with_shards(SHARDS)
-        .with_eviction_config(
-            S3FifoConfig {
-                small_queue_capacity_ratio: 0.1,
-            }
-            .into(),
-        )
+        .with_eviction_config(S3FifoConfig {
+            small_queue_capacity_ratio: 0.1,
+        })
         .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
         .build()
 }

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -307,8 +307,8 @@ where
         self
     }
 
-    pub fn with_eviction_config(mut self, eviction_config: EvictionConfig) -> Self {
-        self.eviction_config = Some(eviction_config);
+    pub fn with_eviction_config(mut self, eviction_config: impl Into<EvictionConfig>) -> Self {
+        self.eviction_config = Some(eviction_config.into());
         self
     }
 
@@ -745,7 +745,7 @@ mod tests {
     fn fifo() -> Cache<u64, u64> {
         CacheBuilder::new(CAPACITY)
             .with_shards(SHARDS)
-            .with_eviction_config(FifoConfig {}.into())
+            .with_eviction_config(FifoConfig {})
             .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
             .build()
     }
@@ -753,12 +753,9 @@ mod tests {
     fn lru() -> Cache<u64, u64> {
         CacheBuilder::new(CAPACITY)
             .with_shards(SHARDS)
-            .with_eviction_config(
-                LruConfig {
-                    high_priority_pool_ratio: 0.1,
-                }
-                .into(),
-            )
+            .with_eviction_config(LruConfig {
+                high_priority_pool_ratio: 0.1,
+            })
             .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
             .build()
     }
@@ -766,15 +763,12 @@ mod tests {
     fn lfu() -> Cache<u64, u64> {
         CacheBuilder::new(CAPACITY)
             .with_shards(SHARDS)
-            .with_eviction_config(
-                LfuConfig {
-                    window_capacity_ratio: 0.1,
-                    protected_capacity_ratio: 0.8,
-                    cmsketch_eps: 0.001,
-                    cmsketch_confidence: 0.9,
-                }
-                .into(),
-            )
+            .with_eviction_config(LfuConfig {
+                window_capacity_ratio: 0.1,
+                protected_capacity_ratio: 0.8,
+                cmsketch_eps: 0.001,
+                cmsketch_confidence: 0.9,
+            })
             .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
             .build()
     }
@@ -782,12 +776,9 @@ mod tests {
     fn s3fifo() -> Cache<u64, u64> {
         CacheBuilder::new(CAPACITY)
             .with_shards(SHARDS)
-            .with_eviction_config(
-                S3FifoConfig {
-                    small_queue_capacity_ratio: 0.1,
-                }
-                .into(),
-            )
+            .with_eviction_config(S3FifoConfig {
+                small_queue_capacity_ratio: 0.1,
+            })
             .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
             .build()
     }

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -16,6 +16,7 @@ use std::{
     borrow::Borrow,
     fmt::Debug,
     hash::{BuildHasher, Hash},
+    marker::PhantomData,
     ops::Deref,
     sync::Arc,
 };
@@ -38,12 +39,11 @@ use crate::{
     indexer::HashTableIndexer,
     listener::{CacheEventListener, DefaultCacheEventListener},
     metrics::Metrics,
+    FifoConfig, LfuConfig, LruConfig, S3FifoConfig,
 };
 
 pub type FifoCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     GenericCache<K, V, Fifo<(K, V)>, HashTableIndexer<K, FifoHandle<(K, V)>>, L, S>;
-pub type FifoCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCacheConfig<K, V, Fifo<(K, V)>, L, S>;
 pub type FifoCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     GenericCacheEntry<K, V, Fifo<(K, V)>, HashTableIndexer<K, FifoHandle<(K, V)>>, L, S>;
 pub type FifoEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState> =
@@ -51,8 +51,6 @@ pub type FifoEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomStat
 
 pub type LruCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     GenericCache<K, V, Lru<(K, V)>, HashTableIndexer<K, LruHandle<(K, V)>>, L, S>;
-pub type LruCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCacheConfig<K, V, Lru<(K, V)>, L, S>;
 pub type LruCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     GenericCacheEntry<K, V, Lru<(K, V)>, HashTableIndexer<K, LruHandle<(K, V)>>, L, S>;
 pub type LruEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState> =
@@ -60,8 +58,6 @@ pub type LruEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState
 
 pub type LfuCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     GenericCache<K, V, Lfu<(K, V)>, HashTableIndexer<K, LfuHandle<(K, V)>>, L, S>;
-pub type LfuCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCacheConfig<K, V, Lfu<(K, V)>, L, S>;
 pub type LfuCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     GenericCacheEntry<K, V, Lfu<(K, V)>, HashTableIndexer<K, LfuHandle<(K, V)>>, L, S>;
 pub type LfuEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState> =
@@ -69,8 +65,6 @@ pub type LfuEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState
 
 pub type S3FifoCache<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     GenericCache<K, V, S3Fifo<(K, V)>, HashTableIndexer<K, S3FifoHandle<(K, V)>>, L, S>;
-pub type S3FifoCacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
-    GenericCacheConfig<K, V, S3Fifo<(K, V)>, L, S>;
 pub type S3FifoCacheEntry<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState> =
     GenericCacheEntry<K, V, S3Fifo<(K, V)>, HashTableIndexer<K, S3FifoHandle<(K, V)>>, L, S>;
 pub type S3FifoEntry<K, V, ER, L = DefaultCacheEventListener<K, V>, S = RandomState> =
@@ -226,64 +220,177 @@ where
     }
 }
 
-pub enum CacheConfig<K, V, L = DefaultCacheEventListener<K, V>, S = RandomState>
-where
-    K: Key,
-    V: Value,
-    L: CacheEventListener<K, V>,
-    S: BuildHasher + Send + Sync + 'static,
-{
-    Fifo(FifoCacheConfig<K, V, L, S>),
-    Lru(LruCacheConfig<K, V, L, S>),
-    Lfu(LfuCacheConfig<K, V, L, S>),
-    S3Fifo(S3FifoCacheConfig<K, V, L, S>),
+#[derive(Debug, Clone)]
+pub enum EvictionConfig {
+    Fifo(FifoConfig),
+    Lru(LruConfig),
+    Lfu(LfuConfig),
+    S3Fifo(S3FifoConfig),
 }
 
-impl<K, V, L, S> From<FifoCacheConfig<K, V, L, S>> for CacheConfig<K, V, L, S>
-where
-    K: Key,
-    V: Value,
-    L: CacheEventListener<K, V>,
-    S: BuildHasher + Send + Sync + 'static,
-{
-    fn from(value: FifoCacheConfig<K, V, L, S>) -> Self {
-        Self::Fifo(value)
+impl From<FifoConfig> for EvictionConfig {
+    fn from(value: FifoConfig) -> EvictionConfig {
+        EvictionConfig::Fifo(value)
     }
 }
 
-impl<K, V, L, S> From<LruCacheConfig<K, V, L, S>> for CacheConfig<K, V, L, S>
-where
-    K: Key,
-    V: Value,
-    L: CacheEventListener<K, V>,
-    S: BuildHasher + Send + Sync + 'static,
-{
-    fn from(value: LruCacheConfig<K, V, L, S>) -> Self {
-        Self::Lru(value)
+impl From<LruConfig> for EvictionConfig {
+    fn from(value: LruConfig) -> EvictionConfig {
+        EvictionConfig::Lru(value)
     }
 }
 
-impl<K, V, L, S> From<LfuCacheConfig<K, V, L, S>> for CacheConfig<K, V, L, S>
-where
-    K: Key,
-    V: Value,
-    L: CacheEventListener<K, V>,
-    S: BuildHasher + Send + Sync + 'static,
-{
-    fn from(value: LfuCacheConfig<K, V, L, S>) -> Self {
-        Self::Lfu(value)
+impl From<LfuConfig> for EvictionConfig {
+    fn from(value: LfuConfig) -> EvictionConfig {
+        EvictionConfig::Lfu(value)
     }
 }
 
-impl<K, V, L, S> From<S3FifoCacheConfig<K, V, L, S>> for CacheConfig<K, V, L, S>
+impl From<S3FifoConfig> for EvictionConfig {
+    fn from(value: S3FifoConfig) -> EvictionConfig {
+        EvictionConfig::S3Fifo(value)
+    }
+}
+
+pub struct CacheBuilder<K, V, L, S>
 where
     K: Key,
     V: Value,
     L: CacheEventListener<K, V>,
     S: BuildHasher + Send + Sync + 'static,
 {
-    fn from(value: S3FifoCacheConfig<K, V, L, S>) -> Self {
-        Self::S3Fifo(value)
+    capacity: usize,
+    shards: Option<usize>,
+    eviction_config: Option<EvictionConfig>,
+    object_pool_capacity: Option<usize>,
+    event_listener: L,
+    hash_builder: S,
+    _marker: PhantomData<(K, V)>,
+}
+
+impl<K, V> CacheBuilder<K, V, DefaultCacheEventListener<K, V>, RandomState>
+where
+    K: Key,
+    V: Value,
+{
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            shards: None,
+            eviction_config: None,
+            object_pool_capacity: None,
+            event_listener: DefaultCacheEventListener::default(),
+            hash_builder: RandomState::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<K, V, L, S> CacheBuilder<K, V, L, S>
+where
+    K: Key,
+    V: Value,
+    L: CacheEventListener<K, V>,
+    S: BuildHasher + Send + Sync + 'static,
+{
+    const DEFAULT_SHARDS: usize = 1;
+    const DEFAULT_EVICTION_CONFIG: EvictionConfig = EvictionConfig::Lfu(LfuConfig {
+        window_capacity_ratio: 0.1,
+        protected_capacity_ratio: 0.8,
+        cmsketch_eps: 0.001,
+        cmsketch_confidence: 0.9,
+    });
+    const DEFAULT_OBJECT_POOL_CAPACITY_RATIO_RECIPROCAL: usize = 10;
+
+    pub fn with_shards(mut self, shards: usize) -> Self {
+        self.shards = Some(shards);
+        self
+    }
+
+    pub fn with_eviction_config(mut self, eviction_config: EvictionConfig) -> Self {
+        self.eviction_config = Some(eviction_config);
+        self
+    }
+
+    pub fn with_object_pool_capacity(mut self, object_pool_capacity: usize) -> Self {
+        self.object_pool_capacity = Some(object_pool_capacity);
+        self
+    }
+
+    pub fn with_event_listener<OL>(self, event_listener: OL) -> CacheBuilder<K, V, OL, S>
+    where
+        OL: CacheEventListener<K, V>,
+    {
+        CacheBuilder {
+            capacity: self.capacity,
+            shards: self.shards,
+            eviction_config: self.eviction_config,
+            object_pool_capacity: self.object_pool_capacity,
+            event_listener,
+            hash_builder: self.hash_builder,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn with_hash_builder<OS>(self, hash_builder: OS) -> CacheBuilder<K, V, L, OS>
+    where
+        OS: BuildHasher + Send + Sync + 'static,
+    {
+        CacheBuilder {
+            capacity: self.capacity,
+            shards: self.shards,
+            eviction_config: self.eviction_config,
+            object_pool_capacity: self.object_pool_capacity,
+            event_listener: self.event_listener,
+            hash_builder,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn build(self) -> Cache<K, V, L, S> {
+        let capacity = self.capacity;
+        let shards = self.shards.unwrap_or(Self::DEFAULT_SHARDS);
+        let eviction_config = self.eviction_config.unwrap_or(Self::DEFAULT_EVICTION_CONFIG);
+        let object_pool_capacity = self
+            .object_pool_capacity
+            .unwrap_or(capacity / Self::DEFAULT_OBJECT_POOL_CAPACITY_RATIO_RECIPROCAL);
+        let event_listener = self.event_listener;
+        let hash_builder = self.hash_builder;
+
+        match eviction_config {
+            EvictionConfig::Fifo(eviction_config) => Cache::Fifo(Arc::new(GenericCache::new(GenericCacheConfig {
+                capacity,
+                shards,
+                eviction_config,
+                object_pool_capacity,
+                hash_builder,
+                event_listener,
+            }))),
+            EvictionConfig::Lru(eviction_config) => Cache::Lru(Arc::new(GenericCache::new(GenericCacheConfig {
+                capacity,
+                shards,
+                eviction_config,
+                object_pool_capacity,
+                hash_builder,
+                event_listener,
+            }))),
+            EvictionConfig::Lfu(eviction_config) => Cache::Lfu(Arc::new(GenericCache::new(GenericCacheConfig {
+                capacity,
+                shards,
+                eviction_config,
+                object_pool_capacity,
+                hash_builder,
+                event_listener,
+            }))),
+            EvictionConfig::S3Fifo(eviction_config) => Cache::S3Fifo(Arc::new(GenericCache::new(GenericCacheConfig {
+                capacity,
+                shards,
+                eviction_config,
+                object_pool_capacity,
+                hash_builder,
+                event_listener,
+            }))),
+        }
     }
 }
 
@@ -341,15 +448,6 @@ where
     L: CacheEventListener<K, V>,
     S: BuildHasher + Send + Sync + 'static,
 {
-    pub fn new(config: CacheConfig<K, V, L, S>) -> Self {
-        match config {
-            CacheConfig::Fifo(config) => Cache::Fifo(Arc::new(GenericCache::new(config))),
-            CacheConfig::Lru(config) => Cache::Lru(Arc::new(GenericCache::new(config))),
-            CacheConfig::Lfu(config) => Cache::Lfu(Arc::new(GenericCache::new(config))),
-            CacheConfig::S3Fifo(config) => Cache::S3Fifo(Arc::new(GenericCache::new(config))),
-        }
-    }
-
     pub fn insert(&self, key: K, value: V, charge: usize) -> CacheEntry<K, V, L, S> {
         match self {
             Cache::Fifo(cache) => cache.insert(key, value, charge).into(),
@@ -645,68 +743,53 @@ mod tests {
     const CONCURRENCY: usize = 8;
 
     fn fifo() -> Cache<u64, u64> {
-        Cache::new(
-            FifoCacheConfig {
-                capacity: CAPACITY,
-                shards: SHARDS,
-                eviction_config: FifoConfig {},
-                object_pool_capacity: OBJECT_POOL_CAPACITY,
-                hash_builder: RandomState::default(),
-                event_listener: DefaultCacheEventListener::default(),
-            }
-            .into(),
-        )
+        CacheBuilder::new(CAPACITY)
+            .with_shards(SHARDS)
+            .with_eviction_config(FifoConfig {}.into())
+            .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
+            .build()
     }
 
     fn lru() -> Cache<u64, u64> {
-        Cache::new(
-            LruCacheConfig {
-                capacity: CAPACITY,
-                shards: SHARDS,
-                eviction_config: LruConfig {
+        CacheBuilder::new(CAPACITY)
+            .with_shards(SHARDS)
+            .with_eviction_config(
+                LruConfig {
                     high_priority_pool_ratio: 0.1,
-                },
-                object_pool_capacity: OBJECT_POOL_CAPACITY,
-                hash_builder: RandomState::default(),
-                event_listener: DefaultCacheEventListener::default(),
-            }
-            .into(),
-        )
+                }
+                .into(),
+            )
+            .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
+            .build()
     }
 
     fn lfu() -> Cache<u64, u64> {
-        Cache::new(
-            LfuCacheConfig {
-                capacity: CAPACITY,
-                shards: SHARDS,
-                eviction_config: LfuConfig {
+        CacheBuilder::new(CAPACITY)
+            .with_shards(SHARDS)
+            .with_eviction_config(
+                LfuConfig {
                     window_capacity_ratio: 0.1,
                     protected_capacity_ratio: 0.8,
                     cmsketch_eps: 0.001,
                     cmsketch_confidence: 0.9,
-                },
-                object_pool_capacity: OBJECT_POOL_CAPACITY,
-                hash_builder: RandomState::default(),
-                event_listener: DefaultCacheEventListener::default(),
-            }
-            .into(),
-        )
+                }
+                .into(),
+            )
+            .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
+            .build()
     }
 
     fn s3fifo() -> Cache<u64, u64> {
-        Cache::new(
-            S3FifoCacheConfig {
-                capacity: CAPACITY,
-                shards: SHARDS,
-                eviction_config: S3FifoConfig {
+        CacheBuilder::new(CAPACITY)
+            .with_shards(SHARDS)
+            .with_eviction_config(
+                S3FifoConfig {
                     small_queue_capacity_ratio: 0.1,
-                },
-                object_pool_capacity: OBJECT_POOL_CAPACITY,
-                hash_builder: RandomState::default(),
-                event_listener: DefaultCacheEventListener::default(),
-            }
-            .into(),
-        )
+                }
+                .into(),
+            )
+            .with_object_pool_capacity(OBJECT_POOL_CAPACITY)
+            .build()
     }
 
     fn init_cache(cache: &Cache<u64, u64>, rng: &mut StdRng) {

--- a/foyer-memory/src/generic.rs
+++ b/foyer-memory/src/generic.rs
@@ -880,7 +880,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        cache::{FifoCache, FifoCacheConfig, FifoCacheEntry, LruCache, LruCacheConfig, LruCacheEntry},
+        cache::{FifoCache, FifoCacheEntry, LruCache, LruCacheEntry},
         eviction::{
             fifo::{FifoConfig, FifoHandle},
             lru::LruConfig,
@@ -894,16 +894,14 @@ mod tests {
     #[test]
     fn test_send_sync_static() {
         is_send_sync_static::<FifoCache<(), ()>>();
-        is_send_sync_static::<FifoCacheConfig<(), ()>>();
         is_send_sync_static::<LruCache<(), ()>>();
-        is_send_sync_static::<LruCacheConfig<(), ()>>();
     }
 
     #[test]
     fn test_cache_fuzzy() {
         const CAPACITY: usize = 256;
 
-        let config = FifoCacheConfig {
+        let config = GenericCacheConfig {
             capacity: CAPACITY,
             shards: 4,
             eviction_config: FifoConfig {},
@@ -927,7 +925,7 @@ mod tests {
     }
 
     fn fifo(capacity: usize) -> Arc<FifoCache<u64, String>> {
-        let config = FifoCacheConfig {
+        let config = GenericCacheConfig {
             capacity,
             shards: 1,
             eviction_config: FifoConfig {},
@@ -939,7 +937,7 @@ mod tests {
     }
 
     fn lru(capacity: usize) -> Arc<LruCache<u64, String>> {
-        let config = LruCacheConfig {
+        let config = GenericCacheConfig {
             capacity,
             shards: 1,
             eviction_config: LruConfig {

--- a/foyer-memory/src/prelude.rs
+++ b/foyer-memory/src/prelude.rs
@@ -13,10 +13,7 @@
 //  limitations under the License.
 
 pub use crate::{
-    cache::{
-        Cache, CacheConfig, CacheEntry, Entry, EntryState, FifoCacheConfig, LfuCacheConfig, LruCacheConfig,
-        S3FifoCacheConfig,
-    },
+    cache::{Cache, CacheBuilder, CacheEntry, Entry, EntryState, EvictionConfig},
     context::CacheContext,
     eviction::{fifo::FifoConfig, lfu::LfuConfig, lru::LruConfig, s3fifo::S3FifoConfig},
     listener::{CacheEventListener, DefaultCacheEventListener},

--- a/foyer-storage-bench/src/main.rs
+++ b/foyer-storage-bench/src/main.rs
@@ -34,13 +34,12 @@ use analyze::{analyze, monitor, Metrics};
 use clap::Parser;
 use export::MetricsExporter;
 use foyer_common::code::{StorageKey, StorageValue};
-use foyer_memory::LfuConfig;
+use foyer_memory::{EvictionConfig, LfuConfig};
 use foyer_storage::{
     admission::{rated_ticket::RatedTicketAdmissionPolicy, AdmissionPolicy},
     compress::Compression,
     device::fs::FsDeviceConfig,
     error::Result,
-    region_manager::EvictionConfg,
     reinsertion::{rated_ticket::RatedTicketReinsertionPolicy, ReinsertionPolicy},
     runtime::{RuntimeConfig, RuntimeStore, RuntimeStoreConfig, RuntimeStoreWriter},
     storage::{AsyncStorageExt, Storage, StorageExt, StorageWriter},
@@ -538,7 +537,7 @@ async fn main() {
     let metrics_dump_start = metrics.dump();
     let time = Instant::now();
 
-    let eviction_config = EvictionConfg::Lfu(LfuConfig {
+    let eviction_config = EvictionConfig::Lfu(LfuConfig {
         window_capacity_ratio: 0.1,
         protected_capacity_ratio: 0.8,
         cmsketch_eps: 0.001,

--- a/foyer-storage/src/generic.rs
+++ b/foyer-storage/src/generic.rs
@@ -31,6 +31,7 @@ use foyer_common::{
     code::{CodingError, StorageKey, StorageValue},
 };
 
+use foyer_memory::EvictionConfig;
 use futures::future::try_join_all;
 use itertools::Itertools;
 use parking_lot::Mutex;
@@ -51,7 +52,7 @@ use crate::{
     metrics::{Metrics, METRICS},
     reclaimer::Reclaimer,
     region::{Region, RegionHeader, RegionId},
-    region_manager::{EvictionConfg, RegionManager},
+    region_manager::RegionManager,
     reinsertion::{ReinsertionContext, ReinsertionPolicy},
     storage::{Storage, StorageWriter},
 };
@@ -70,7 +71,7 @@ where
     pub name: String,
 
     /// Evictino policy configurations.
-    pub eviction_config: EvictionConfg,
+    pub eviction_config: EvictionConfig,
 
     /// Device configurations.
     pub device_config: D::Config,
@@ -1072,7 +1073,7 @@ mod tests {
 
         let config = TestStoreConfig {
             name: "".to_string(),
-            eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+            eviction_config: EvictionConfig::Fifo(FifoConfig {}),
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 16 * MB,
@@ -1118,7 +1119,7 @@ mod tests {
 
         let config = TestStoreConfig {
             name: "".to_string(),
-            eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+            eviction_config: EvictionConfig::Fifo(FifoConfig {}),
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 16 * MB,

--- a/foyer-storage/src/lazy.rs
+++ b/foyer-storage/src/lazy.rs
@@ -227,12 +227,11 @@ pub type LazyStoreWriter<K, V> = LazyStorageWriter<K, V, Store<K, V>>;
 mod tests {
     use std::path::PathBuf;
 
-    use foyer_memory::FifoConfig;
+    use foyer_memory::{EvictionConfig, FifoConfig};
 
     use super::*;
     use crate::{
         device::fs::FsDeviceConfig,
-        region_manager::EvictionConfg,
         storage::StorageExt,
         store::{FsStore, FsStoreConfig},
     };
@@ -246,7 +245,7 @@ mod tests {
 
         let config = FsStoreConfig {
             name: "".to_string(),
-            eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+            eviction_config: EvictionConfig::Fifo(FifoConfig {}),
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 16 * MB,
@@ -278,7 +277,7 @@ mod tests {
 
         let config = FsStoreConfig {
             name: "".to_string(),
-            eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+            eviction_config: EvictionConfig::Fifo(FifoConfig {}),
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 16 * MB,

--- a/foyer-storage/src/storage.rs
+++ b/foyer-storage/src/storage.rs
@@ -322,13 +322,12 @@ mod tests {
 
     use std::{path::Path, sync::Arc, time::Duration};
 
-    use foyer_memory::FifoConfig;
+    use foyer_memory::{EvictionConfig, FifoConfig};
     use tokio::sync::Barrier;
 
     use super::*;
     use crate::{
         device::fs::FsDeviceConfig,
-        region_manager::EvictionConfg,
         store::{FsStore, FsStoreConfig},
     };
 
@@ -338,7 +337,7 @@ mod tests {
     fn config_for_test(dir: impl AsRef<Path>) -> FsStoreConfig<u64, Vec<u8>> {
         FsStoreConfig {
             name: "".to_string(),
-            eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+            eviction_config: EvictionConfig::Fifo(FifoConfig {}),
             device_config: FsDeviceConfig {
                 dir: dir.as_ref().into(),
                 capacity: 4 * MB,

--- a/foyer-storage/tests/storage_test.rs
+++ b/foyer-storage/tests/storage_test.rs
@@ -17,12 +17,11 @@
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use foyer_memory::FifoConfig;
+use foyer_memory::{EvictionConfig, FifoConfig};
 use foyer_storage::{
     compress::Compression,
     device::fs::FsDeviceConfig,
     lazy::LazyStore,
-    region_manager::EvictionConfg,
     runtime::{RuntimeConfig, RuntimeLazyStore, RuntimeStorageConfig, RuntimeStore},
     storage::{Storage, StorageExt},
     store::{FsStore, FsStoreConfig},
@@ -108,7 +107,7 @@ async fn test_store() {
     let recorder = Arc::new(JudgeRecorder::default());
     let config = FsStoreConfig {
         name: "".to_string(),
-        eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+        eviction_config: EvictionConfig::Fifo(FifoConfig {}),
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
@@ -135,7 +134,7 @@ async fn test_store_zstd() {
     let recorder = Arc::new(JudgeRecorder::default());
     let config = FsStoreConfig {
         name: "".to_string(),
-        eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+        eviction_config: EvictionConfig::Fifo(FifoConfig {}),
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
@@ -162,7 +161,7 @@ async fn test_store_lz4() {
     let recorder = Arc::new(JudgeRecorder::default());
     let config = FsStoreConfig {
         name: "".to_string(),
-        eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+        eviction_config: EvictionConfig::Fifo(FifoConfig {}),
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
@@ -189,7 +188,7 @@ async fn test_lazy_store() {
     let recorder = Arc::new(JudgeRecorder::default());
     let config = FsStoreConfig {
         name: "".to_string(),
-        eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+        eviction_config: EvictionConfig::Fifo(FifoConfig {}),
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
@@ -217,7 +216,7 @@ async fn test_runtime_store() {
     let config = RuntimeStorageConfig {
         store: FsStoreConfig {
             name: "".to_string(),
-            eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+            eviction_config: EvictionConfig::Fifo(FifoConfig {}),
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 4 * MB,
@@ -251,7 +250,7 @@ async fn test_runtime_lazy_store() {
     let config = RuntimeStorageConfig {
         store: FsStoreConfig {
             name: "".to_string(),
-            eviction_config: EvictionConfg::Fifo(FifoConfig {}),
+            eviction_config: EvictionConfig::Fifo(FifoConfig {}),
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 4 * MB,


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Introduce `CacheBuilder` to make in-memory cache build much easier.

Thanks @wenym1 for help. 🙏

Before (with default args):

```rust
    let cache = Cache::new(
        LfuCacheConfig {
            capacity: 1000,
            shards: 1,
            eviction_config: LfuConfig {
                window_capacity_ratio: 0.1,
                protected_capacity_ratio: 0.8,
                cmsketch_eps: 0.001,
                cmsketch_confidence: 0.9,
            },
            object_pool_capacity: 100,
            hash_builder: RandomState::default(),
            event_listener: DefaultCacheEventListener::default(),
        }
        .into(),
    );
```

After (with default args):

```rust
    let cache = CacheBuilder::new(1000).build();
```

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#327 