### PR TITLE
feat: introduce fs device config builder to auto detect config

### DIFF
--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -88,11 +88,13 @@ jobs:
       - name: Run rust test with coverage (igored tests)
         env:
           RUST_BACKTRACE: 1
+          CI: true
         run: |
           cargo llvm-cov --no-report nextest --run-ignored ignored-only --no-capture --workspace
       - name: Run rust test with coverage
         env:
           RUST_BACKTRACE: 1
+          CI: true
         run: |
           cargo llvm-cov --no-report nextest
       - name: Generate codecov report
@@ -130,6 +132,7 @@ jobs:
           RUSTFLAGS: "--cfg tokio_unstable"
           RUST_LOG: info
           TOKIO_WORKER_THREADS: 1
+          CI: true
         run: |-
           cargo build --all --features deadlock
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage-bench/deadlock
@@ -159,6 +162,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=address --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} test --lib --bins --tests --target x86_64-unknown-linux-gnu -- --nocapture
       - name: Run foyer-storage-bench With Address Sanitizer
@@ -166,6 +170,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=address --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage-bench/asan
@@ -205,6 +210,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=leak --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} test --lib --bins --tests --target x86_64-unknown-linux-gnu -- --nocapture
       - name: Run foyer-storage-bench With Leak Sanitizer
@@ -212,6 +218,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=leak --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage-bench/lsan
@@ -255,6 +262,7 @@ jobs:
           RUSTFLAGS: "--cfg tokio_unstable --cfg madsim"
           RUST_LOG: info
           TOKIO_WORKER_THREADS: 1
+          CI: true
         run: |-
           cargo clippy --all-targets
       - name: Run nextest (madsim)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,11 +95,13 @@ jobs:
       - name: Run rust test with coverage (igored tests)
         env:
           RUST_BACKTRACE: 1
+          CI: true
         run: |
           cargo llvm-cov --no-report nextest --run-ignored ignored-only --no-capture --workspace
       - name: Run rust test with coverage
         env:
           RUST_BACKTRACE: 1
+          CI: true
         run: |
           cargo llvm-cov --no-report nextest
       - name: Generate codecov report
@@ -137,6 +139,7 @@ jobs:
           RUSTFLAGS: "--cfg tokio_unstable"
           RUST_LOG: info
           TOKIO_WORKER_THREADS: 1
+          CI: true
         run: |-
           cargo build --all --features deadlock
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage-bench/deadlock
@@ -166,6 +169,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=address --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} test --lib --bins --tests --target x86_64-unknown-linux-gnu -- --nocapture
       - name: Run foyer-storage-bench With Address Sanitizer
@@ -173,6 +177,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=address --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage-bench/asan
@@ -212,6 +217,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=leak --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} test --lib --bins --tests --target x86_64-unknown-linux-gnu -- --nocapture
       - name: Run foyer-storage-bench With Leak Sanitizer
@@ -219,6 +225,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=leak --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage-bench/lsan
@@ -262,6 +269,7 @@ jobs:
           RUSTFLAGS: "--cfg tokio_unstable --cfg madsim"
           RUST_LOG: info
           TOKIO_WORKER_THREADS: 1
+          CI: true
         run: |-
           cargo clippy --all-targets
       - name: Run nextest (madsim)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -94,11 +94,13 @@ jobs:
       - name: Run rust test with coverage (igored tests)
         env:
           RUST_BACKTRACE: 1
+          CI: true
         run: |
           cargo llvm-cov --no-report nextest --run-ignored ignored-only --no-capture --workspace
       - name: Run rust test with coverage
         env:
           RUST_BACKTRACE: 1
+          CI: true
         run: |
           cargo llvm-cov --no-report nextest
       - name: Generate codecov report
@@ -136,6 +138,7 @@ jobs:
           RUSTFLAGS: "--cfg tokio_unstable"
           RUST_LOG: info
           TOKIO_WORKER_THREADS: 1
+          CI: true
         run: |-
           cargo build --all --features deadlock
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage-bench/deadlock
@@ -165,6 +168,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=address --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} test --lib --bins --tests --target x86_64-unknown-linux-gnu -- --nocapture
       - name: Run foyer-storage-bench With Address Sanitizer
@@ -172,6 +176,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=address --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage-bench/asan
@@ -211,6 +216,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=leak --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} test --lib --bins --tests --target x86_64-unknown-linux-gnu -- --nocapture
       - name: Run foyer-storage-bench With Leak Sanitizer
@@ -218,6 +224,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=leak --cfg tokio_unstable"
           RUST_LOG: info
+          CI: true
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage-bench/lsan
@@ -261,6 +268,7 @@ jobs:
           RUSTFLAGS: "--cfg tokio_unstable --cfg madsim"
           RUST_LOG: info
           TOKIO_WORKER_THREADS: 1
+          CI: true
         run: |-
           cargo clippy --all-targets
       - name: Run nextest (madsim)

--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "1"
 cfg-if = "1"
 foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }
 itertools = "0.12"
+nix = { version = "0.28", features = ["fs"] }
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 paste = "1.0"
 tokio = { workspace = true }

--- a/foyer-common/src/fs.rs
+++ b/foyer-common/src/fs.rs
@@ -24,7 +24,10 @@ pub fn freespace(path: impl AsRef<Path>) -> Result<usize, Errno> {
 
 #[cfg(test)]
 mod tests {
-    use std::{env::current_dir, process::Command};
+    use std::{
+        env::{current_dir, var},
+        process::Command,
+    };
 
     use super::*;
     use itertools::Itertools;
@@ -32,25 +35,27 @@ mod tests {
     #[test]
     #[ignore]
     fn test() {
-        let dir = current_dir().unwrap();
-        let path = dir.as_os_str().to_str().unwrap();
+        if var("CI").unwrap_or("".to_string()) != "true" {
+            let dir = current_dir().unwrap();
+            let path = dir.as_os_str().to_str().unwrap();
 
-        println!("{}", path);
+            println!("{}", path);
 
-        let v1 = freespace(path).unwrap();
-        let df = String::from_utf8(Command::new("df").args(["-P", path]).output().unwrap().stdout).unwrap();
-        let bs: usize = df.trim().split('\n').next().unwrap().split_whitespace().collect_vec()[1]
-            .strip_suffix("-blocks")
-            .unwrap()
-            .parse()
-            .unwrap();
-        let av: usize = df.trim().split('\n').last().unwrap().split_whitespace().collect_vec()[3]
-            .parse()
-            .unwrap();
-        let v2 = bs * av;
+            let v1 = freespace(path).unwrap();
+            let df = String::from_utf8(Command::new("df").args(["-P", path]).output().unwrap().stdout).unwrap();
+            let bs: usize = df.trim().split('\n').next().unwrap().split_whitespace().collect_vec()[1]
+                .strip_suffix("-blocks")
+                .unwrap()
+                .parse()
+                .unwrap();
+            let av: usize = df.trim().split('\n').last().unwrap().split_whitespace().collect_vec()[3]
+                .parse()
+                .unwrap();
+            let v2 = bs * av;
 
-        println!("{}", df);
+            println!("{}", df);
 
-        assert_eq!(v1, v2);
+            assert_eq!(v1, v2);
+        }
     }
 }

--- a/foyer-common/src/fs.rs
+++ b/foyer-common/src/fs.rs
@@ -30,6 +30,7 @@ mod tests {
     use itertools::Itertools;
 
     #[test]
+    #[ignore]
     fn test() {
         let dir = current_dir().unwrap();
         let path = dir.as_os_str().to_str().unwrap();

--- a/foyer-common/src/fs.rs
+++ b/foyer-common/src/fs.rs
@@ -1,0 +1,53 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::path::Path;
+
+use nix::{errno::Errno, sys::statvfs::statvfs};
+
+pub fn free_space(path: impl AsRef<Path>) -> Result<usize, Errno> {
+    let stat = statvfs(path.as_ref())?;
+    let res = stat.blocks_available() * stat.block_size();
+    Ok(res as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env::current_dir, process::Command};
+
+    use super::*;
+    use itertools::Itertools;
+
+    #[test]
+    fn test() {
+        let dir = current_dir().unwrap();
+        let path = dir.as_os_str().to_str().unwrap();
+
+        println!("{}", path);
+
+        let v1 = free_space(path).unwrap();
+        let df = String::from_utf8(Command::new("df").args(["-P", path]).output().unwrap().stdout).unwrap();
+        let bs: usize = df.trim().split('\n').next().unwrap().split_whitespace().collect_vec()[1]
+            .strip_suffix("-blocks")
+            .unwrap()
+            .parse()
+            .unwrap();
+        let av: usize = df.trim().split('\n').last().unwrap().split_whitespace().collect_vec()[3]
+            .parse()
+            .unwrap();
+        let v2 = bs * av;
+
+        assert_eq!(v1, v2);
+    }
+}

--- a/foyer-common/src/fs.rs
+++ b/foyer-common/src/fs.rs
@@ -18,8 +18,8 @@ use nix::{errno::Errno, sys::statvfs::statvfs};
 
 pub fn free_space(path: impl AsRef<Path>) -> Result<usize, Errno> {
     let stat = statvfs(path.as_ref())?;
-    let res = stat.blocks_available() * stat.block_size();
-    Ok(res as usize)
+    let res = stat.blocks_available() as usize * stat.block_size() as usize;
+    Ok(res)
 }
 
 #[cfg(test)]

--- a/foyer-common/src/fs.rs
+++ b/foyer-common/src/fs.rs
@@ -16,17 +16,9 @@ use std::path::Path;
 
 use nix::{errno::Errno, sys::statvfs::statvfs};
 
-#[cfg(target_os = "linux")]
 pub fn freespace(path: impl AsRef<Path>) -> Result<usize, Errno> {
     let stat = statvfs(path.as_ref())?;
-    let res = stat.blocks_available() as usize * stat.block_size() as usize;
-    Ok(res)
-}
-
-#[cfg(target_os = "macos")]
-pub fn freespace(path: impl AsRef<Path>) -> Result<usize, Errno> {
-    let stat = statvfs(path.as_ref())?;
-    let res = stat.blocks_available() as usize;
+    let res = stat.blocks_available() as usize * stat.fragment_size() as usize;
     Ok(res)
 }
 

--- a/foyer-common/src/lib.rs
+++ b/foyer-common/src/lib.rs
@@ -25,3 +25,6 @@ pub mod range;
 pub mod rate;
 pub mod rated_ticket;
 pub mod runtime;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub mod fs;

--- a/foyer-storage-bench/src/main.rs
+++ b/foyer-storage-bench/src/main.rs
@@ -547,7 +547,7 @@ async fn main() {
     let device_config = FsDeviceConfig {
         dir: PathBuf::from(&args.dir),
         capacity: args.capacity * 1024 * 1024,
-        file_capacity: args.region_size * 1024 * 1024,
+        file_size: args.region_size * 1024 * 1024,
         align: args.align,
         io_size: args.io_size,
     };

--- a/foyer-storage/src/buffer.rs
+++ b/foyer-storage/src/buffer.rs
@@ -331,10 +331,10 @@ mod tests {
 
         let device = FsDevice::open(FsDeviceConfig {
             dir: tempdir.path().into(),
-            capacity: 256 * 1024,     // 256 KiB
-            file_capacity: 64 * 1024, // 64 KiB
-            align: 4 * 1024,          // 4 KiB
-            io_size: 16 * 1024,       // 16 KiB
+            capacity: 256 * 1024, // 256 KiB
+            file_size: 64 * 1024, // 64 KiB
+            align: 4 * 1024,      // 4 KiB
+            io_size: 16 * 1024,   // 16 KiB
         })
         .await
         .unwrap();

--- a/foyer-storage/src/device/fs.rs
+++ b/foyer-storage/src/device/fs.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use allocator_api2::vec::Vec as VecA;
-use foyer_common::{fs::free_space, range::RangeBoundsExt};
+use foyer_common::{fs::freespace, range::RangeBoundsExt};
 use futures::future::try_join_all;
 use itertools::Itertools;
 
@@ -79,7 +79,7 @@ impl FsDeviceConfigBuilder {
 
         let align = self.align.unwrap_or(Self::DEFAULT_ALIGN);
 
-        let capacity = self.capacity.unwrap_or(free_space(&dir).unwrap() / 10 * 8);
+        let capacity = self.capacity.unwrap_or(freespace(&dir).unwrap() / 10 * 8);
         let capacity = align_v(capacity, align);
 
         let file_size = self.file_size.unwrap_or(Self::DEFAULT_FILE_SIZE).clamp(align, capacity);

--- a/foyer-storage/src/device/fs.rs
+++ b/foyer-storage/src/device/fs.rs
@@ -15,17 +15,90 @@
 use std::{
     fs::{create_dir_all, File, OpenOptions},
     os::fd::{AsRawFd, BorrowedFd, RawFd},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
 use allocator_api2::vec::Vec as VecA;
-use foyer_common::range::RangeBoundsExt;
+use foyer_common::{fs::free_space, range::RangeBoundsExt};
 use futures::future::try_join_all;
 use itertools::Itertools;
 
 use super::{allocator::AlignedAllocator, asyncify, Device, DeviceError, DeviceResult, IoBuf, IoBufMut, IoRange};
 use crate::region::RegionId;
+
+#[derive(Debug)]
+pub struct FsDeviceConfigBuilder {
+    pub dir: PathBuf,
+    pub capacity: Option<usize>,
+    pub file_size: Option<usize>,
+    pub align: Option<usize>,
+    pub io_size: Option<usize>,
+}
+
+impl FsDeviceConfigBuilder {
+    const DEFAULT_ALIGN: usize = 4096;
+    const DEFAULT_IO_SIZE: usize = 16 * 1024;
+    const DEFAULT_FILE_SIZE: usize = 64 * 1024 * 1024;
+
+    pub fn new(dir: impl AsRef<Path>) -> Self {
+        let dir = dir.as_ref().into();
+        Self {
+            dir,
+            capacity: None,
+            file_size: None,
+            align: None,
+            io_size: None,
+        }
+    }
+
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = Some(capacity);
+        self
+    }
+
+    pub fn with_file_size(mut self, file_size: usize) -> Self {
+        self.file_size = Some(file_size);
+        self
+    }
+
+    pub fn with_align(mut self, align: usize) -> Self {
+        self.align = Some(align);
+        self
+    }
+
+    pub fn with_io_size(mut self, io_size: usize) -> Self {
+        self.io_size = Some(io_size);
+        self
+    }
+
+    pub fn build(self) -> FsDeviceConfig {
+        let align_v = |value: usize, align: usize| value - value % align;
+
+        let dir = self.dir;
+
+        let align = self.align.unwrap_or(Self::DEFAULT_ALIGN);
+
+        let capacity = self.capacity.unwrap_or(free_space(&dir).unwrap() / 10 * 8);
+        let capacity = align_v(capacity, align);
+
+        let file_size = self.file_size.unwrap_or(Self::DEFAULT_FILE_SIZE).clamp(align, capacity);
+        let file_size = align_v(file_size, align);
+
+        let capacity = align_v(capacity, file_size);
+
+        let io_size = self.io_size.unwrap_or(Self::DEFAULT_IO_SIZE).max(align);
+        let io_size = align_v(io_size, align);
+
+        FsDeviceConfig {
+            dir,
+            capacity,
+            file_size,
+            align,
+            io_size,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct FsDeviceConfig {
@@ -36,7 +109,7 @@ pub struct FsDeviceConfig {
     pub capacity: usize,
 
     /// must be multipliers of `align`
-    pub file_capacity: usize,
+    pub file_size: usize,
 
     /// io block alignment, must be pow of 2
     pub align: usize,
@@ -46,10 +119,10 @@ pub struct FsDeviceConfig {
 }
 
 impl FsDeviceConfig {
-    pub fn verify(&self) {
+    pub fn assert(&self) {
         assert!(self.align.is_power_of_two());
-        assert_eq!(self.file_capacity % self.align, 0);
-        assert_eq!(self.capacity % self.file_capacity, 0);
+        assert_eq!(self.file_size % self.align, 0);
+        assert_eq!(self.capacity % self.file_size, 0);
     }
 }
 
@@ -83,7 +156,7 @@ impl Device for FsDevice {
     where
         B: IoBuf,
     {
-        let file_capacity = self.inner.config.file_capacity;
+        let file_capacity = self.inner.config.file_size;
 
         let range = range.bounds(0..buf.as_ref().len());
         let len = RangeBoundsExt::size(&range).unwrap();
@@ -113,7 +186,7 @@ impl Device for FsDevice {
     where
         B: IoBufMut,
     {
-        let file_capacity = self.inner.config.file_capacity;
+        let file_capacity = self.inner.config.file_size;
 
         let range = range.bounds(0..buf.as_ref().len());
         let len = RangeBoundsExt::size(&range).unwrap();
@@ -179,11 +252,11 @@ impl Device for FsDevice {
 
 impl FsDevice {
     pub async fn open(config: FsDeviceConfig) -> DeviceResult<Self> {
-        config.verify();
+        config.assert();
 
         // TODO(MrCroxx): write and read config to a manifest file for pinning
 
-        let regions = config.capacity / config.file_capacity;
+        let regions = config.capacity / config.file_size;
 
         let path = config.dir.clone();
         let dir = asyncify(move || {
@@ -238,6 +311,8 @@ impl FsDevice {
 #[cfg(test)]
 mod tests {
 
+    use std::env::current_dir;
+
     use bytes::BufMut;
 
     use super::*;
@@ -253,7 +328,7 @@ mod tests {
         let config = FsDeviceConfig {
             dir: PathBuf::from(dir.path()),
             capacity: CAPACITY,
-            file_capacity: FILE_CAPACITY,
+            file_size: FILE_CAPACITY,
             align: ALIGN,
             io_size: ALIGN,
         };
@@ -273,5 +348,15 @@ mod tests {
 
         drop(wbuffer);
         drop(rbuffer);
+    }
+
+    #[test]
+    fn test_config_builder() {
+        let dir = current_dir().unwrap();
+        let config = FsDeviceConfigBuilder::new(dir).build();
+
+        println!("{config:?}");
+
+        config.assert();
     }
 }

--- a/foyer-storage/src/generic.rs
+++ b/foyer-storage/src/generic.rs
@@ -1077,7 +1077,7 @@ mod tests {
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 16 * MB,
-                file_capacity: 4 * MB,
+                file_size: 4 * MB,
                 align: 4 * KB,
                 io_size: 4 * KB,
             },
@@ -1123,7 +1123,7 @@ mod tests {
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 16 * MB,
-                file_capacity: 4 * MB,
+                file_size: 4 * MB,
                 align: 4096,
                 io_size: 4096 * KB,
             },

--- a/foyer-storage/src/lazy.rs
+++ b/foyer-storage/src/lazy.rs
@@ -218,7 +218,7 @@ mod tests {
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 16 * MB,
-                file_capacity: 4 * MB,
+                file_size: 4 * MB,
                 align: 4096,
                 io_size: 4096 * KB,
             },
@@ -250,7 +250,7 @@ mod tests {
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 16 * MB,
-                file_capacity: 4 * MB,
+                file_size: 4 * MB,
                 align: 4096,
                 io_size: 4096 * KB,
             },

--- a/foyer-storage/src/storage.rs
+++ b/foyer-storage/src/storage.rs
@@ -341,7 +341,7 @@ mod tests {
             device_config: FsDeviceConfig {
                 dir: dir.as_ref().into(),
                 capacity: 4 * MB,
-                file_capacity: MB,
+                file_size: MB,
                 align: 4 * KB,
                 io_size: 4 * KB,
             },

--- a/foyer-storage/tests/storage_test.rs
+++ b/foyer-storage/tests/storage_test.rs
@@ -111,7 +111,7 @@ async fn test_store() {
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
-            file_capacity: 1 * MB,
+            file_size: 1 * MB,
             align: 4 * KB,
             io_size: 4 * KB,
         },
@@ -138,7 +138,7 @@ async fn test_store_zstd() {
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
-            file_capacity: 1 * MB,
+            file_size: 1 * MB,
             align: 4 * KB,
             io_size: 4 * KB,
         },
@@ -165,7 +165,7 @@ async fn test_store_lz4() {
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
-            file_capacity: 1 * MB,
+            file_size: 1 * MB,
             align: 4 * KB,
             io_size: 4 * KB,
         },
@@ -192,7 +192,7 @@ async fn test_lazy_store() {
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
-            file_capacity: 1 * MB,
+            file_size: 1 * MB,
             align: 4 * KB,
             io_size: 4 * KB,
         },
@@ -220,7 +220,7 @@ async fn test_runtime_store() {
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 4 * MB,
-                file_capacity: 1 * MB,
+                file_size: 1 * MB,
                 align: 4 * KB,
                 io_size: 4 * KB,
             },
@@ -254,7 +254,7 @@ async fn test_runtime_lazy_store() {
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 4 * MB,
-                file_capacity: 1 * MB,
+                file_size: 1 * MB,
                 align: 4 * KB,
                 io_size: 4 * KB,
             },

--- a/foyer-workspace-hack/Cargo.toml
+++ b/foyer-workspace-hack/Cargo.toml
@@ -31,7 +31,7 @@ futures-sink = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "channel", "io", "sink"] }
 hashbrown = { version = "0.14", features = ["raw"] }
 itertools = { version = "0.12" }
-libc = { version = "0.2", features = ["extra_traits"] }
+nix = { version = "0.28", features = ["fs", "mman", "uio"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "deadlock_detection"] }
 parking_lot_core = { version = "0.9", default-features = false, features = ["deadlock_detection"] }
 rand = { version = "0.8", features = ["small_rng"] }


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

The fs device config builder will use 80% space of the given path by default.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#327 