### PR TITLE
refactor: remove `Clone` bound for storage key and value

### DIFF
--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -14,11 +14,13 @@ readme = "../README.md"
 normal = ["foyer-workspace-hack"]
 
 [dependencies]
+ahash = "0.8"
 anyhow = "1.0"
 bytes = "1"
 cfg-if = "1"
 crossbeam = "0.8"
 foyer-workspace-hack = { version = "0.4", path = "../foyer-workspace-hack" }
+hashbrown = "0.14"
 itertools = "0.12"
 nix = { version = "0.28", features = ["fs"] }
 parking_lot = { version = "0.12", features = ["arc_lock"] }

--- a/foyer-common/src/arc_key_hash_map.rs
+++ b/foyer-common/src/arc_key_hash_map.rs
@@ -1,0 +1,178 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::{
+    borrow::Borrow,
+    fmt::Debug,
+    hash::{BuildHasher, Hash},
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+use ahash::RandomState;
+use hashbrown::hash_table::{HashTable, IntoIter as HashTableIntoIter};
+
+pub use hashbrown::hash_table::Entry;
+
+pub struct HashTableEntry<K, V> {
+    key: Arc<K>,
+    value: V,
+    hash: u64,
+}
+
+impl<K, V> HashTableEntry<K, V> {
+    pub fn key(&self) -> &Arc<K> {
+        &self.key
+    }
+
+    pub fn value(&self) -> &V {
+        &self.value
+    }
+
+    pub fn take(self) -> (Arc<K>, V) {
+        (self.key, self.value)
+    }
+}
+
+pub struct ArcKeyHashMap<K, V, S = RandomState> {
+    inner: HashTable<HashTableEntry<K, V>>,
+    build_hasher: S,
+}
+
+impl<K, V> Debug for ArcKeyHashMap<K, V, RandomState> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArcHashMap").finish()
+    }
+}
+
+impl<K, V> Default for ArcKeyHashMap<K, V, RandomState> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> ArcKeyHashMap<K, V, RandomState> {
+    pub fn new() -> Self {
+        Self::new_with_hasher(RandomState::default())
+    }
+}
+
+impl<K, V, S> ArcKeyHashMap<K, V, S> {
+    pub fn new_with_hasher(build_hasher: S) -> Self {
+        Self {
+            inner: HashTable::new(),
+            build_hasher,
+        }
+    }
+}
+
+impl<K, V, S> Deref for ArcKeyHashMap<K, V, S> {
+    type Target = HashTable<HashTableEntry<K, V>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<K, V, S> DerefMut for ArcKeyHashMap<K, V, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<K, V, S> ArcKeyHashMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Send + Sync + 'static,
+{
+    pub fn insert(&mut self, key: Arc<K>, value: V) -> Option<V> {
+        let hash = self.build_hasher.hash_one(&key);
+        match self.inner.entry(
+            hash,
+            |entry| entry.key.as_ref().borrow() == key.as_ref(),
+            |entry| entry.hash,
+        ) {
+            Entry::Occupied(mut o) => {
+                let mut e = HashTableEntry { key, value, hash };
+                std::mem::swap(o.get_mut(), &mut e);
+                Some(e.value)
+            }
+            Entry::Vacant(v) => {
+                v.insert(HashTableEntry { key, value, hash });
+                None
+            }
+        }
+    }
+
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.build_hasher.hash_one(key);
+        self.inner
+            .find(hash, |entry| entry.key.as_ref().borrow() == key)
+            .map(|entry| &entry.value)
+    }
+
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.build_hasher.hash_one(key);
+        match self
+            .inner
+            .entry(hash, |entry| entry.key.as_ref().borrow() == key, |entry| entry.hash)
+        {
+            Entry::Occupied(o) => {
+                let (entry, _v) = o.remove();
+                Some(entry.value)
+            }
+            Entry::Vacant(_) => None,
+        }
+    }
+
+    pub fn entry(&mut self, key: Arc<K>) -> Entry<'_, HashTableEntry<K, V>> {
+        let hash = self.build_hasher.hash_one(&key);
+        self.inner.entry(
+            hash,
+            |entry| entry.key.as_ref().borrow() == key.as_ref(),
+            |entry| entry.hash,
+        )
+    }
+}
+
+pub struct IntoIter<K, V> {
+    inner: HashTableIntoIter<HashTableEntry<K, V>>,
+}
+
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (Arc<K>, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|entry| (entry.key, entry.value))
+    }
+}
+
+impl<K, V, S> IntoIterator for ArcKeyHashMap<K, V, S> {
+    type Item = (Arc<K>, V);
+    type IntoIter = IntoIter<K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.inner.into_iter(),
+        }
+    }
+}

--- a/foyer-common/src/code.rs
+++ b/foyer-common/src/code.rs
@@ -22,16 +22,10 @@ pub trait Value: Send + Sync + 'static {}
 impl<T: Send + Sync + 'static + std::hash::Hash + Eq> Key for T {}
 impl<T: Send + Sync + 'static> Value for T {}
 
-/// [`StorageKey`] is required to implement [`Clone`].
-///
-/// If cloning a [`StorageKey`] is expensive, wrap it with [`Arc`].
 // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
-pub trait StorageKey: Key + Debug + Clone + Serialize + DeserializeOwned {}
-impl<T> StorageKey for T where T: Key + Debug + Clone + Serialize + DeserializeOwned {}
+pub trait StorageKey: Key + Debug + Serialize + DeserializeOwned {}
+impl<T> StorageKey for T where T: Key + Debug + Serialize + DeserializeOwned {}
 
-/// [`StorageValue`] is required to implement [`Clone`].
-///
-/// If cloning a [`StorageValue`] is expensive, wrap it with [`Arc`].
 // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
 pub trait StorageValue: Value + 'static + Debug + Clone + Serialize + DeserializeOwned {}
 impl<T> StorageValue for T where T: Value + Debug + Clone + Serialize + DeserializeOwned {}

--- a/foyer-common/src/lib.rs
+++ b/foyer-common/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
+pub mod arc_key_hash_map;
 pub mod async_queue;
 pub mod batch;
 pub mod bits;

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -16,7 +16,7 @@ normal = ["foyer-workspace-hack"]
 [dependencies]
 ahash = "0.8"
 # TODO(MrCroxx): Remove this after `allocator_api` is stable.
-allocator-api2 = "0.2"                                       
+allocator-api2 = "0.2"
 anyhow = "1.0"
 bincode = "1"
 bitflags = "2.3.1"

--- a/foyer-storage/src/admission/mod.rs
+++ b/foyer-storage/src/admission/mod.rs
@@ -48,10 +48,6 @@ pub trait AdmissionPolicy: Send + Sync + 'static + Debug {
     fn init(&self, context: AdmissionContext<Self::Key, Self::Value>);
 
     fn judge(&self, key: &Self::Key) -> bool;
-
-    fn on_insert(&self, key: &Self::Key, judge: bool);
-
-    fn on_drop(&self, key: &Self::Key, judge: bool);
 }
 
 pub mod rated_ticket;

--- a/foyer-storage/src/admission/rated_ticket.rs
+++ b/foyer-storage/src/admission/rated_ticket.rs
@@ -82,8 +82,4 @@ where
 
         res
     }
-
-    fn on_insert(&self, _key: &Self::Key, _judge: bool) {}
-
-    fn on_drop(&self, _key: &Self::Key, _judge: bool) {}
 }

--- a/foyer-storage/src/buffer.rs
+++ b/foyer-storage/src/buffer.rs
@@ -306,6 +306,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use tempfile::tempdir;
 
     use super::*;
@@ -313,8 +315,8 @@ mod tests {
 
     fn ent(size: usize) -> Entry<(), Vec<u8>> {
         Entry {
-            key: (),
-            value: vec![b'x'; size],
+            key: Arc::new(()),
+            value: Arc::new(vec![b'x'; size]),
             compression: Compression::None,
             sequence: 0,
         }
@@ -328,7 +330,7 @@ mod tests {
                 &b[EntryHeader::serialized_len()..EntryHeader::serialized_len() + h.value_len as usize],
             )
             .unwrap();
-            assert_eq!(v, positioned.entry.value);
+            assert_eq!(v, positioned.entry.value.as_ref());
         }
     }
 

--- a/foyer-storage/src/flusher.rs
+++ b/foyer-storage/src/flusher.rs
@@ -34,8 +34,8 @@ where
     K: StorageKey,
     V: StorageValue,
 {
-    pub key: K,
-    pub value: V,
+    pub key: Arc<K>,
+    pub value: Arc<V>,
     pub sequence: Sequence,
     pub compression: Compression,
 }

--- a/foyer-storage/src/judge.rs
+++ b/foyer-storage/src/judge.rs
@@ -43,6 +43,8 @@ impl Judges {
         }
     }
 
+    // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
+    #[allow(unused)]
     pub fn get(&mut self, index: usize) -> bool {
         self.judge.get(index)
     }

--- a/foyer-storage/src/none.rs
+++ b/foyer-storage/src/none.rs
@@ -19,7 +19,7 @@ use foyer_common::code::{StorageKey, StorageValue};
 use crate::{
     compress::Compression,
     error::Result,
-    storage::{Storage, StorageWriter},
+    storage::{CachedEntry, Storage, StorageWriter},
 };
 
 #[derive(Debug)]
@@ -60,8 +60,8 @@ where
 
     fn force(&mut self) {}
 
-    async fn finish(self, _: V) -> Result<bool> {
-        Ok(false)
+    async fn finish(self, _: V) -> Result<Option<CachedEntry<K, V>>> {
+        Ok(None)
     }
 
     fn compression(&self) -> Compression {
@@ -114,7 +114,7 @@ impl<K: StorageKey, V: StorageValue> Storage<K, V> for NoneStore<K, V> {
         Ok(false)
     }
 
-    async fn lookup<Q>(&self, _: &Q) -> Result<Option<V>>
+    async fn lookup<Q>(&self, _: &Q) -> Result<Option<CachedEntry<K, V>>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -20,6 +20,6 @@ pub use crate::{
     metrics::{get_metrics_registry, set_metrics_registry},
     reinsertion::{rated_ticket::RatedTicketReinsertionPolicy, ReinsertionContext, ReinsertionPolicy},
     runtime::{RuntimeConfig, RuntimeConfigBuilder, RuntimeStoreConfig},
-    storage::{AsyncStorageExt, ForceStorageExt, Storage, StorageExt, StorageWriter},
+    storage::{AsyncStorageExt, CachedEntry, ForceStorageExt, Storage, StorageExt, StorageWriter},
     store::{FsStoreConfig, Store, StoreBuilder, StoreConfig, StoreWriter},
 };

--- a/foyer-storage/src/reinsertion/exist.rs
+++ b/foyer-storage/src/reinsertion/exist.rs
@@ -57,8 +57,4 @@ where
         let indices = self.catalog.get().unwrap();
         indices.lookup(key).is_some()
     }
-
-    fn on_insert(&self, _key: &Self::Key, _judge: bool) {}
-
-    fn on_drop(&self, _key: &Self::Key, _judge: bool) {}
 }

--- a/foyer-storage/src/reinsertion/mod.rs
+++ b/foyer-storage/src/reinsertion/mod.rs
@@ -48,10 +48,6 @@ pub trait ReinsertionPolicy: Send + Sync + 'static + Debug {
     fn init(&self, context: ReinsertionContext<Self::Key, Self::Value>);
 
     fn judge(&self, key: &Self::Key) -> bool;
-
-    fn on_insert(&self, key: &Self::Key, judge: bool);
-
-    fn on_drop(&self, key: &Self::Key, judge: bool);
 }
 
 pub mod exist;

--- a/foyer-storage/src/reinsertion/rated_ticket.rs
+++ b/foyer-storage/src/reinsertion/rated_ticket.rs
@@ -81,8 +81,4 @@ where
 
         res
     }
-
-    fn on_insert(&self, _key: &Self::Key, _judge: bool) {}
-
-    fn on_drop(&self, _key: &Self::Key, _judge: bool) {}
 }

--- a/foyer-storage/src/test_utils.rs
+++ b/foyer-storage/src/test_utils.rs
@@ -40,8 +40,8 @@ where
 
 impl<K, V> JudgeRecorder<K, V>
 where
-    K: StorageKey,
-    V: StorageValue,
+    K: StorageKey + Clone,
+    V: StorageValue + Clone,
 {
     pub fn dump(&self) -> Vec<Record<K>> {
         self.records.lock().clone()
@@ -79,8 +79,8 @@ where
 
 impl<K, V> AdmissionPolicy for JudgeRecorder<K, V>
 where
-    K: StorageKey,
-    V: StorageValue,
+    K: StorageKey + Clone,
+    V: StorageValue + Clone,
 {
     type Key = K;
 
@@ -92,16 +92,12 @@ where
         self.records.lock().push(Record::Admit(key.clone()));
         true
     }
-
-    fn on_insert(&self, _key: &K, _judge: bool) {}
-
-    fn on_drop(&self, _key: &K, _judge: bool) {}
 }
 
 impl<K, V> ReinsertionPolicy for JudgeRecorder<K, V>
 where
-    K: StorageKey,
-    V: StorageValue,
+    K: StorageKey + Clone,
+    V: StorageValue + Clone,
 {
     type Key = K;
 
@@ -113,8 +109,4 @@ where
         self.records.lock().push(Record::Evict(key.clone()));
         false
     }
-
-    fn on_insert(&self, _key: &Self::Key, _judge: bool) {}
-
-    fn on_drop(&self, _key: &Self::Key, _judge: bool) {}
 }

--- a/foyer-storage/tests/storage_test.rs
+++ b/foyer-storage/tests/storage_test.rs
@@ -17,7 +17,7 @@
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use foyer_memory::{EvictionConfig, FifoConfig};
+use foyer_memory::FifoConfig;
 use foyer_storage::{
     test_utils::JudgeRecorder, Compression, FsDeviceConfig, FsStoreConfig, RuntimeConfigBuilder, RuntimeStoreConfig,
     Storage, StorageExt, Store, StoreConfig,
@@ -48,7 +48,7 @@ async fn test_store(config: StoreConfig<u64, Vec<u8>>, recorder: Arc<JudgeRecord
 
     for i in 0..INSERTS as u64 * (LOOPS + 1) as u64 {
         if remains.contains(&i) {
-            assert_eq!(store.lookup(&i).await.unwrap().unwrap(), vec![i as u8; 1 * KB],);
+            assert_eq!(store.lookup(&i).await.unwrap().unwrap().value(), &vec![i as u8; 1 * KB],);
         } else {
             assert!(store.lookup(&i).await.unwrap().is_none());
         }
@@ -66,7 +66,7 @@ async fn test_store(config: StoreConfig<u64, Vec<u8>>, recorder: Arc<JudgeRecord
 
         for i in 0..INSERTS as u64 * (LOOPS + 1) as u64 {
             if remains.contains(&i) {
-                assert_eq!(store.lookup(&i).await.unwrap().unwrap(), vec![i as u8; 1 * KB],);
+                assert_eq!(store.lookup(&i).await.unwrap().unwrap().value(), &vec![i as u8; 1 * KB],);
             } else {
                 assert!(store.lookup(&i).await.unwrap().is_none());
             }
@@ -83,7 +83,7 @@ async fn test_store(config: StoreConfig<u64, Vec<u8>>, recorder: Arc<JudgeRecord
 
         for i in 0..INSERTS as u64 * (LOOPS + 1) as u64 {
             if remains.contains(&i) {
-                assert_eq!(store.lookup(&i).await.unwrap().unwrap(), vec![i as u8; 1 * KB],);
+                assert_eq!(store.lookup(&i).await.unwrap().unwrap().value(), &vec![i as u8; 1 * KB],);
             } else {
                 assert!(store.lookup(&i).await.unwrap().is_none());
             }
@@ -99,7 +99,7 @@ async fn test_fs_store() {
     let recorder = Arc::new(JudgeRecorder::default());
     let config = StoreConfig::Fs(FsStoreConfig {
         name: "".to_string(),
-        eviction_config: EvictionConfig::Fifo(FifoConfig {}),
+        eviction_config: FifoConfig {}.into(),
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
@@ -126,7 +126,7 @@ async fn test_fs_store_zstd() {
     let recorder = Arc::new(JudgeRecorder::default());
     let config = StoreConfig::Fs(FsStoreConfig {
         name: "".to_string(),
-        eviction_config: EvictionConfig::Fifo(FifoConfig {}),
+        eviction_config: FifoConfig {}.into(),
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
@@ -153,7 +153,7 @@ async fn test_fs_store_lz4() {
     let recorder = Arc::new(JudgeRecorder::default());
     let config = StoreConfig::Fs(FsStoreConfig {
         name: "".to_string(),
-        eviction_config: EvictionConfig::Fifo(FifoConfig {}),
+        eviction_config: FifoConfig {}.into(),
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
@@ -180,7 +180,7 @@ async fn test_lazy_fs_store() {
     let recorder = Arc::new(JudgeRecorder::default());
     let config = StoreConfig::LazyFs(FsStoreConfig {
         name: "".to_string(),
-        eviction_config: EvictionConfig::Fifo(FifoConfig {}),
+        eviction_config: FifoConfig {}.into(),
         device_config: FsDeviceConfig {
             dir: PathBuf::from(tempdir.path()),
             capacity: 4 * MB,
@@ -208,7 +208,7 @@ async fn test_runtime_fs_store() {
     let config = StoreConfig::RuntimeFs(RuntimeStoreConfig {
         store_config: FsStoreConfig {
             name: "".to_string(),
-            eviction_config: EvictionConfig::Fifo(FifoConfig {}),
+            eviction_config: FifoConfig {}.into(),
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 4 * MB,
@@ -238,7 +238,7 @@ async fn test_runtime_lazy_fs_store() {
     let config = StoreConfig::RuntimeLazyFs(RuntimeStoreConfig {
         store_config: FsStoreConfig {
             name: "".to_string(),
-            eviction_config: EvictionConfig::Fifo(FifoConfig {}),
+            eviction_config: FifoConfig {}.into(),
             device_config: FsDeviceConfig {
                 dir: PathBuf::from(tempdir.path()),
                 capacity: 4 * MB,

--- a/foyer-workspace-hack/Cargo.toml
+++ b/foyer-workspace-hack/Cargo.toml
@@ -29,6 +29,7 @@ futures-core = { version = "0.3" }
 futures-executor = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "channel", "io", "sink"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
 hashbrown = { version = "0.14", features = ["raw"] }
 itertools = { version = "0.12" }
 nix = { version = "0.28", features = ["fs", "mman", "uio"] }


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

Modification:

- Use `Arc<K>` and `Arc<V>` instead of `K` and `V` if necessary.
- Remove `on_insert` and `on_drop` callback for admission and reinsertion policies.
- Lookup return `Option<CachedEntry<K, V>>` which holds shared pointer or owned pointer instead of `Option<V>` directly.
- Catalog uses `ArcKeyHashMap` with `hashbrown::HashTable` to implement key comparing (which doesn't require `Arc<K>: Borrow<Q>`) instead of std hash map.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #364