### PR TITLE
fix: call syncfs when fs device flush on macos

### DIFF
--- a/foyer-storage/src/device/fs.rs
+++ b/foyer-storage/src/device/fs.rs
@@ -209,10 +209,7 @@ impl Device for FsDevice {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     async fn flush(&self) -> DeviceResult<()> {
         let fd = self.inner.dir.as_raw_fd();
-        // Commit fs cache to disk. Linux waits for I/O completions.
-        //
-        // See also [syncfs(2)](https://man7.org/linux/man-pages/man2/sync.2.html)
-        asyncify(move || nix::unistd::syncfs(fd).map_err(DeviceError::from)).await?;
+        asyncify(move || nix::unistd::fsync(fd).map_err(DeviceError::from)).await?;
         Ok(())
     }
 

--- a/foyer-storage/src/device/fs.rs
+++ b/foyer-storage/src/device/fs.rs
@@ -206,7 +206,7 @@ impl Device for FsDevice {
         .await
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     async fn flush(&self) -> DeviceResult<()> {
         let fd = self.inner.dir.as_raw_fd();
         // Commit fs cache to disk. Linux waits for I/O completions.
@@ -216,7 +216,7 @@ impl Device for FsDevice {
         Ok(())
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     async fn flush(&self) -> DeviceResult<()> {
         // TODO(MrCroxx): track dirty files and call fsync(2) on them on other target os.
         Ok(())


### PR DESCRIPTION
Signed-off-by: MrCroxx <mrcroxx@outlook.com>## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Use `sync(2)` on MacOS.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #320