### PR TITLE
feat: introduce recover mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ use anyhow::Result;
 use chrono::Datelike;
 use foyer::{
     CacheContext, FsDeviceConfigBuilder, HybridCache, HybridCacheBuilder, LfuConfig, LruConfig,
-    RatedTicketAdmissionPolicy, RatedTicketReinsertionPolicy, RuntimeConfigBuilder,
+    RatedTicketAdmissionPolicy, RatedTicketReinsertionPolicy, RecoverMode, RuntimeConfigBuilder,
 };
 use tempfile::tempdir;
 
@@ -126,6 +126,7 @@ async fn main() -> Result<()> {
         .with_flushers(2)
         .with_reclaimers(2)
         .with_clean_region_threshold(2)
+        .with_recover_mode(RecoverMode::QuietRecovery)
         .with_recover_concurrency(4)
         .with_compression(foyer::Compression::Lz4)
         .with_flush(true)

--- a/examples/hybrid_full.rs
+++ b/examples/hybrid_full.rs
@@ -18,7 +18,7 @@ use anyhow::Result;
 use chrono::Datelike;
 use foyer::{
     CacheContext, FsDeviceConfigBuilder, HybridCache, HybridCacheBuilder, LfuConfig, LruConfig,
-    RatedTicketAdmissionPolicy, RatedTicketReinsertionPolicy, RuntimeConfigBuilder,
+    RatedTicketAdmissionPolicy, RatedTicketReinsertionPolicy, RecoverMode, RuntimeConfigBuilder,
 };
 use tempfile::tempdir;
 
@@ -57,6 +57,7 @@ async fn main() -> Result<()> {
         .with_flushers(2)
         .with_reclaimers(2)
         .with_clean_region_threshold(2)
+        .with_recover_mode(RecoverMode::QuietRecovery)
         .with_recover_concurrency(4)
         .with_compression(foyer::Compression::Lz4)
         .with_flush(false)

--- a/foyer-storage/src/catalog.rs
+++ b/foyer-storage/src/catalog.rs
@@ -12,7 +12,13 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::{borrow::Borrow, fmt::Debug, hash::Hash, sync::Arc, time::Instant};
+use std::{
+    borrow::Borrow,
+    fmt::Debug,
+    hash::Hash,
+    sync::{atomic::AtomicU64, Arc},
+    time::Instant,
+};
 
 use ahash::RandomState;
 use foyer_common::{
@@ -28,6 +34,7 @@ use crate::{
 };
 
 pub type Sequence = u64;
+pub type AtomicSequence = AtomicU64;
 
 #[derive(Debug)]
 pub enum Index<K, V>

--- a/foyer-storage/src/device/fs.rs
+++ b/foyer-storage/src/device/fs.rs
@@ -164,7 +164,8 @@ impl Device for FsDevice {
 
         assert!(
             offset + len <= file_capacity,
-            "offset ({offset}) + len ({len}) <= file capacity ({file_capacity})"
+            "offset ({offset}) + len ({len}) = {} <= file capacity ({file_capacity})",
+            offset + len
         );
 
         let file = self.file(region).clone();
@@ -258,6 +259,8 @@ impl Device for FsDevice {
 }
 
 impl FsDevice {
+    pub const PREFIX: &'static str = "foyer-cache-";
+
     pub async fn open(config: FsDeviceConfig) -> DeviceResult<Self> {
         config.assert();
 
@@ -312,7 +315,7 @@ impl FsDevice {
     }
 
     fn filename(region: RegionId) -> String {
-        format!("foyer-cache-{:08}", region)
+        format!("{}{:08}", Self::PREFIX, region)
     }
 }
 

--- a/foyer-storage/src/lazy.rs
+++ b/foyer-storage/src/lazy.rs
@@ -243,6 +243,7 @@ mod tests {
     use super::*;
     use crate::{
         device::fs::FsDeviceConfig,
+        generic::RecoverMode,
         storage::StorageExt,
         store::{FsStore, FsStoreConfig},
     };
@@ -269,6 +270,7 @@ mod tests {
             reinsertions: vec![],
             flushers: 1,
             reclaimers: 1,
+            recover_mode: RecoverMode::default(),
             recover_concurrency: 2,
             clean_region_threshold: 1,
             compression: crate::compress::Compression::None,
@@ -302,6 +304,7 @@ mod tests {
             reinsertions: vec![],
             flushers: 1,
             reclaimers: 1,
+            recover_mode: RecoverMode::default(),
             recover_concurrency: 2,
             clean_region_threshold: 1,
             compression: crate::compress::Compression::None,

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -17,6 +17,7 @@ pub use crate::{
     compress::Compression,
     device::fs::{FsDeviceConfig, FsDeviceConfigBuilder},
     error::{Error, Result},
+    generic::RecoverMode,
     metrics::{get_metrics_registry, set_metrics_registry},
     reinsertion::{
         exist::ExistReinsertionPolicy, rated_ticket::RatedTicketReinsertionPolicy, ReinsertionContext,

--- a/foyer-storage/src/storage.rs
+++ b/foyer-storage/src/storage.rs
@@ -466,6 +466,7 @@ mod tests {
     use crate::{
         device::fs::FsDeviceConfig,
         store::{FsStore, FsStoreConfig},
+        RecoverMode,
     };
 
     const KB: usize = 1024;
@@ -488,6 +489,7 @@ mod tests {
             flushers: 1,
             reclaimers: 1,
             clean_region_threshold: 1,
+            recover_mode: RecoverMode::default(),
             recover_concurrency: 2,
             compression: Compression::None,
             flush: false,

--- a/foyer-storage/tests/storage_test.rs
+++ b/foyer-storage/tests/storage_test.rs
@@ -19,8 +19,8 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use foyer_memory::FifoConfig;
 use foyer_storage::{
-    test_utils::JudgeRecorder, Compression, FsDeviceConfig, FsStoreConfig, RuntimeConfigBuilder, RuntimeStoreConfig,
-    Storage, StorageExt, Store, StoreConfig,
+    test_utils::JudgeRecorder, Compression, FsDeviceConfig, FsStoreConfig, RecoverMode, RuntimeConfigBuilder,
+    RuntimeStoreConfig, Storage, StorageExt, Store, StoreConfig,
 };
 
 const KB: usize = 1024;
@@ -113,6 +113,7 @@ async fn test_fs_store() {
         flushers: 1,
         reclaimers: 1,
         clean_region_threshold: 1,
+        recover_mode: RecoverMode::default(),
         recover_concurrency: 2,
         compression: Compression::None,
         flush: true,
@@ -141,6 +142,7 @@ async fn test_fs_store_zstd() {
         flushers: 1,
         reclaimers: 1,
         clean_region_threshold: 1,
+        recover_mode: RecoverMode::default(),
         recover_concurrency: 2,
         compression: Compression::Zstd,
         flush: true,
@@ -169,6 +171,7 @@ async fn test_fs_store_lz4() {
         flushers: 1,
         reclaimers: 1,
         clean_region_threshold: 1,
+        recover_mode: RecoverMode::default(),
         recover_concurrency: 2,
         compression: Compression::Lz4,
         flush: true,
@@ -197,6 +200,7 @@ async fn test_lazy_fs_store() {
         flushers: 1,
         reclaimers: 1,
         clean_region_threshold: 1,
+        recover_mode: RecoverMode::default(),
         recover_concurrency: 2,
         compression: Compression::None,
         flush: true,
@@ -226,6 +230,7 @@ async fn test_runtime_fs_store() {
             flushers: 1,
             reclaimers: 1,
             clean_region_threshold: 1,
+            recover_mode: RecoverMode::default(),
             recover_concurrency: 2,
             compression: Compression::None,
             flush: true,
@@ -257,6 +262,7 @@ async fn test_runtime_lazy_fs_store() {
             flushers: 1,
             reclaimers: 1,
             clean_region_threshold: 1,
+            recover_mode: RecoverMode::default(),
             recover_concurrency: 2,
             compression: Compression::None,
             flush: true,

--- a/foyer/src/hybrid.rs
+++ b/foyer/src/hybrid.rs
@@ -26,8 +26,8 @@ use foyer_memory::{
     Cache, CacheBuilder, CacheContext, CacheEntry, CacheEventListener, Entry, EvictionConfig, Weighter,
 };
 use foyer_storage::{
-    AdmissionPolicy, AsyncStorageExt, Compression, DeviceConfig, ReinsertionPolicy, RuntimeConfig, Storage, Store,
-    StoreBuilder,
+    AdmissionPolicy, AsyncStorageExt, Compression, DeviceConfig, RecoverMode, ReinsertionPolicy, RuntimeConfig,
+    Storage, Store, StoreBuilder,
 };
 
 struct HybridCacheEventListenerInner<K, V>
@@ -297,6 +297,18 @@ where
     /// The default clean region thrshold is the reclaimer count.
     pub fn with_clean_region_threshold(self, clean_region_threshold: usize) -> Self {
         let builder = self.builder.with_clean_region_threshold(clean_region_threshold);
+        Self {
+            listener: self.listener,
+            cache: self.cache,
+            builder,
+        }
+    }
+
+    /// Set recover mode.
+    ///
+    /// See [`RecoverMode`].
+    pub fn with_recover_mode(self, recover_mode: RecoverMode) -> Self {
+        let builder = self.builder.with_recover_mode(recover_mode);
         Self {
             listener: self.listener,
             cache: self.cache,

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -26,7 +26,7 @@ pub use common::{
 pub use memory::{CacheContext, EntryState, EvictionConfig, FifoConfig, LfuConfig, LruConfig, Metrics, S3FifoConfig};
 pub use storage::{
     get_metrics_registry, set_metrics_registry, AdmissionContext, AdmissionPolicy, Compression, ExistReinsertionPolicy,
-    FsDeviceConfig, FsDeviceConfigBuilder, RatedTicketAdmissionPolicy, RatedTicketReinsertionPolicy,
+    FsDeviceConfig, FsDeviceConfigBuilder, RatedTicketAdmissionPolicy, RatedTicketReinsertionPolicy, RecoverMode,
     ReinsertionContext, ReinsertionPolicy, RuntimeConfigBuilder, Storage, StorageExt, StorageWriter,
 };
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

```rust
#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
pub enum RecoverMode {
    /// Do not recover disk cache.
    NoRecovery,
    /// Recover disk cache and skip errors.
    QuietRecovery,
    /// Recover disk cache and panic on errors.
    StrictRecovery,
}

impl Default for RecoverMode {
    fn default() -> Self {
        Self::QuietRecovery
    }
}
```

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #382 