### PR TITLE
refactor: rename region view to region address

### DIFF
--- a/foyer-storage/src/flusher.rs
+++ b/foyer-storage/src/flusher.rs
@@ -185,7 +185,7 @@ where
             bytes += len;
             let index = Index::Region {
                 key: key.clone(),
-                view: self.region_manager.region(&region).view(offset as u32, len as u32),
+                address: self.region_manager.region(&region).view(offset as u32, len as u32),
             };
             let item = Item::new(sequence, index);
             self.catalog.insert(key, item);


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

`RegionView` used to contains a atomic ref count which is used by `ErwLock`. For `ErwLock` is not used now, let's remove the rc, too.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
