### PR TITLE
feat: impl runtime store for the new engine

### DIFF
--- a/foyer-common/src/asyncify.rs
+++ b/foyer-common/src/asyncify.rs
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use tokio::runtime::Handle;
+
 #[cfg(not(madsim))]
 pub async fn asyncify<F, T>(f: F) -> T
 where
@@ -23,6 +25,24 @@ where
 
 #[cfg(madsim)]
 pub async fn asyncify<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    f()
+}
+
+#[cfg(not(madsim))]
+pub async fn asyncify_with_runtime<F, T>(runtime: &Handle, f: F) -> T
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    runtime.spawn_blocking(f).await.unwrap()
+}
+
+#[cfg(madsim)]
+pub async fn asyncify_with_runtime<F, T>(_: &Handle, f: F) -> T
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,

--- a/foyer-storage/src/large/flusher.rs
+++ b/foyer-storage/src/large/flusher.rs
@@ -26,6 +26,7 @@ use foyer_common::code::{StorageKey, StorageValue};
 use foyer_memory::CacheEntry;
 use futures::future::{try_join, try_join_all};
 
+use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 
 use super::device::{Device, DeviceExt, IoBuffer, RegionId, IO_BUFFER_ALLOCATOR};
@@ -240,8 +241,9 @@ where
         region_manager: RegionManager<D>,
         device: D,
         tombstone_log: Option<TombstoneLog>,
+        runtime: Handle,
     ) -> Result<Self> {
-        let batch = AsyncBatchPipeline::new(BatchState::default());
+        let batch = AsyncBatchPipeline::with_runtime(BatchState::default(), runtime);
 
         Ok(Self {
             batch,

--- a/foyer-storage/src/large/mod.rs
+++ b/foyer-storage/src/large/mod.rs
@@ -22,6 +22,7 @@ pub mod reclaimer;
 pub mod recover;
 pub mod region;
 pub mod reinsertion;
+pub mod runtime;
 pub mod scanner;
 pub mod storage;
 pub mod tombstone;

--- a/foyer-storage/src/large/runtime.rs
+++ b/foyer-storage/src/large/runtime.rs
@@ -1,0 +1,282 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::{
+    borrow::Borrow,
+    fmt::Debug,
+    hash::{BuildHasher, Hash},
+    sync::Arc,
+};
+
+use foyer_common::{
+    code::{StorageKey, StorageValue},
+    runtime::BackgroundShutdownRuntime,
+};
+use foyer_memory::CacheEntry;
+use futures::{Future, FutureExt};
+
+use crate::error::Result;
+
+use super::storage::{EnqueueFuture, Storage};
+
+pub struct RuntimeConfigBuilder {
+    worker_threads: Option<usize>,
+    thread_name: String,
+}
+
+impl Default for RuntimeConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RuntimeConfigBuilder {
+    pub fn new() -> Self {
+        Self {
+            worker_threads: None,
+            thread_name: "foyer".to_string(),
+        }
+    }
+
+    pub fn with_worker_threads(mut self, worker_threads: usize) -> Self {
+        self.worker_threads = Some(worker_threads);
+        self
+    }
+
+    pub fn with_thread_name(mut self, thread_name: &str) -> Self {
+        self.thread_name = thread_name.to_string();
+        self
+    }
+
+    pub fn build(self) -> RuntimeConfig {
+        RuntimeConfig {
+            worker_threads: self.worker_threads,
+            thread_name: self.thread_name,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    worker_threads: Option<usize>,
+    thread_name: String,
+}
+
+pub struct RuntimeStoreConfig<K, V, S, SS>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: BuildHasher + Send + Sync + 'static + Debug,
+    SS: Storage<Key = K, Value = V, BuildHasher = S>,
+{
+    pub store_config: SS::Config,
+    pub runtime_config: RuntimeConfig,
+}
+
+impl<K, V, S, SS> Debug for RuntimeStoreConfig<K, V, S, SS>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: BuildHasher + Send + Sync + 'static + Debug,
+    SS: Storage<Key = K, Value = V, BuildHasher = S>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuntimeStoreConfig")
+            .field("store_config", &self.store_config)
+            .field("runtime_config", &self.runtime_config)
+            .finish()
+    }
+}
+
+pub struct Runtime<K, V, S, SS>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: BuildHasher + Send + Sync + 'static + Debug,
+    SS: Storage<Key = K, Value = V, BuildHasher = S>,
+{
+    runtime: Arc<BackgroundShutdownRuntime>,
+    store: SS,
+}
+
+impl<K, V, S, SS> Clone for Runtime<K, V, S, SS>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: BuildHasher + Send + Sync + 'static + Debug,
+    SS: Storage<Key = K, Value = V, BuildHasher = S>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            runtime: self.runtime.clone(),
+            store: self.store.clone(),
+        }
+    }
+}
+
+impl<K, V, S, SS> Storage for Runtime<K, V, S, SS>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: BuildHasher + Send + Sync + 'static + Debug,
+    SS: Storage<Key = K, Value = V, BuildHasher = S>,
+{
+    type Key = K;
+    type Value = V;
+    type BuildHasher = S;
+
+    type Config = RuntimeStoreConfig<K, V, S, SS>;
+
+    async fn open(config: Self::Config) -> Result<Self> {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        if let Some(worker_threads) = config.runtime_config.worker_threads {
+            builder.worker_threads(worker_threads);
+        }
+        builder.thread_name(config.runtime_config.thread_name);
+
+        let runtime = builder.enable_all().build().map_err(anyhow::Error::from)?;
+        let runtime = BackgroundShutdownRuntime::from(runtime);
+        let runtime = Arc::new(runtime);
+        let store = runtime
+            .spawn(async move { SS::open(config.store_config).await })
+            .await
+            .unwrap()?;
+        Ok(Self { runtime, store })
+    }
+
+    async fn close(&self) -> Result<()> {
+        let store = self.store.clone();
+        self.runtime.spawn(async move { store.close().await }).await.unwrap()
+    }
+
+    fn enqueue(&self, entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>) -> EnqueueFuture {
+        self.store.enqueue(entry)
+    }
+
+    fn load<Q>(&self, key: &Q) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static
+    where
+        Self::Key: Borrow<Q>,
+        Q: Hash + Eq + ?Sized + Send + Sync + 'static,
+    {
+        let future = self.store.load(key);
+        self.runtime.spawn(future).map(|join_result| join_result.unwrap())
+    }
+
+    fn delete<Q>(&self, key: &Q) -> EnqueueFuture
+    where
+        Self::Key: Borrow<Q>,
+        Q: Hash + Eq + ?Sized + Send + Sync + 'static,
+    {
+        self.store.delete(key)
+    }
+
+    async fn destroy(&self) -> Result<()> {
+        self.store.destroy().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use ahash::RandomState;
+    use foyer_memory::{Cache, CacheBuilder, FifoConfig};
+    use futures::future::try_join_all;
+    use itertools::Itertools;
+
+    use crate::{
+        large::{
+            admission::AdmitAllPicker,
+            device::direct_fs::{DirectFsDevice, DirectFsDeviceConfig},
+            eviction::FifoPicker,
+            generic::{GenericStore, GenericStoreConfig},
+            recover::RecoverMode,
+            reinsertion::DenyAllPicker,
+            storage::Storage,
+        },
+        Compression,
+    };
+
+    use super::*;
+
+    const KB: usize = 1024;
+
+    fn cache_for_test() -> Cache<u64, Vec<u8>> {
+        CacheBuilder::new(10)
+            .with_eviction_config(FifoConfig::default())
+            .build()
+    }
+    fn config_for_test(
+        memory: &Cache<u64, Vec<u8>>,
+        dir: impl AsRef<Path>,
+    ) -> GenericStoreConfig<u64, Vec<u8>, RandomState, DirectFsDevice> {
+        GenericStoreConfig {
+            memory: memory.clone(),
+            device_config: DirectFsDeviceConfig {
+                dir: dir.as_ref().into(),
+                capacity: 64 * KB,
+                file_size: 16 * KB,
+            },
+            compression: Compression::None,
+            flush: true,
+            indexer_shards: 4,
+            recover_mode: RecoverMode::StrictRecovery,
+            recover_concurrency: 2,
+            flushers: 1,
+            reclaimers: 1,
+            clean_region_threshold: 1,
+            eviction_pickers: vec![Box::<FifoPicker>::default()],
+            admission_picker: Box::<AdmitAllPicker<u64>>::default(),
+            reinsertion_picker: Arc::<DenyAllPicker<u64>>::default(),
+            tombstone_log_config: None,
+        }
+    }
+
+    #[test_log::test]
+    fn test_runtime_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let background = BackgroundShutdownRuntime::from(
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .map_err(anyhow::Error::from)
+                .unwrap(),
+        );
+        let memory = cache_for_test();
+
+        let es = (0..100).map(|i| memory.insert(i, vec![i as u8; 7 * KB])).collect_vec();
+
+        let config = config_for_test(&memory, dir);
+        let store = background.block_on(async move { GenericStore::open(config).await.unwrap() });
+
+        let fs = es.iter().cloned().map(|e| store.enqueue(e)).collect_vec();
+        background.block_on(async { try_join_all(fs).await.unwrap() });
+
+        let mut fs = vec![];
+        for i in 0..100 {
+            fs.push(store.load(&i));
+        }
+        background.block_on(async { try_join_all(fs).await.unwrap() });
+
+        let mut fs = vec![];
+        for i in 0..100 {
+            fs.push(store.delete(&i));
+        }
+        background.block_on(async { try_join_all(fs).await.unwrap() });
+
+        background.block_on(async { store.close().await.unwrap() });
+
+        drop(store);
+    }
+}

--- a/foyer-storage/src/large/storage.rs
+++ b/foyer-storage/src/large/storage.rs
@@ -66,7 +66,7 @@ pub trait Storage: Send + Sync + 'static + Clone {
     fn enqueue(&self, entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>) -> EnqueueFuture;
 
     #[must_use]
-    fn lookup<Q>(&self, key: &Q) -> impl Future<Output = Result<Option<Self::Value>>> + Send
+    fn load<Q>(&self, key: &Q) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static
     where
         Self::Key: Borrow<Q>,
         Q: Hash + Eq + ?Sized + Send + Sync + 'static;


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

Make sure all spawned tasks are spawned by the dedicated runtime.

After this PR, `lookup` is removed, and is replaced with `load`, which requires the caller to check if the loaded entry has the correct key.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#449