### PR TITLE
feat: impl deposit for in-memory cache

### DIFF
--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -467,6 +467,32 @@ where
         }
     }
 
+    pub fn deposit<AK, AV>(&self, key: AK, value: AV) -> CacheEntry<K, V, S>
+    where
+        AK: Into<Arc<K>> + Send + 'static,
+        AV: Into<Arc<V>> + Send + 'static,
+    {
+        match self {
+            Cache::Fifo(cache) => cache.deposit(key, value).into(),
+            Cache::Lru(cache) => cache.deposit(key, value).into(),
+            Cache::Lfu(cache) => cache.deposit(key, value).into(),
+            Cache::S3Fifo(cache) => cache.deposit(key, value).into(),
+        }
+    }
+
+    pub fn deposit_with_context<AK, AV>(&self, key: AK, value: AV, context: CacheContext) -> CacheEntry<K, V, S>
+    where
+        AK: Into<Arc<K>> + Send + 'static,
+        AV: Into<Arc<V>> + Send + 'static,
+    {
+        match self {
+            Cache::Fifo(cache) => cache.deposit_with_context(key, value, context).into(),
+            Cache::Lru(cache) => cache.deposit_with_context(key, value, context).into(),
+            Cache::Lfu(cache) => cache.deposit_with_context(key, value, context).into(),
+            Cache::S3Fifo(cache) => cache.deposit_with_context(key, value, context).into(),
+        }
+    }
+
     pub fn remove<Q>(&self, key: &Q) -> Option<CacheEntry<K, V, S>>
     where
         K: Borrow<Q>,

--- a/foyer-memory/src/handle.rs
+++ b/foyer-memory/src/handle.rs
@@ -23,6 +23,7 @@ bitflags! {
     struct BaseHandleFlags: u8 {
         const IN_INDEXER = 0b00000001;
         const IN_EVICTION = 0b00000010;
+        const IS_DEPOSIT= 0b00000100;
     }
 }
 
@@ -219,6 +220,20 @@ impl<T, C> BaseHandle<T, C> {
     #[inline(always)]
     pub fn is_in_eviction(&self) -> bool {
         !(self.flags & BaseHandleFlags::IN_EVICTION).is_empty()
+    }
+
+    #[inline(always)]
+    pub fn set_deposit(&mut self, deposit: bool) {
+        if deposit {
+            self.flags |= BaseHandleFlags::IS_DEPOSIT;
+        } else {
+            self.flags -= BaseHandleFlags::IS_DEPOSIT;
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_deposit(&self) -> bool {
+        !(self.flags & BaseHandleFlags::IS_DEPOSIT).is_empty()
     }
 }
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title. `deposit` means temporarily using the in-memory cache for indexing. It will be removed after there is no external reference no matter if the cache has exceeded its capacity (But it does occupy its weight.). It is useful for inserting the new disk cache only. (e.g. RisingWave does compaction refill for disk cache only, the new engine needs to use the in-memory cache for indexing.)

When a "deposit" entry is accessed, it will be promoted to be a normal entry.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#447 #449