### PR TITLE
fix: fix reinsertion ut

### DIFF
--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -793,6 +793,9 @@ mod tests {
 
         // [ [], [e2, e3], [e4, e5], [e6, e1] ]
         assert!(store.enqueue(es[6].clone()).await.unwrap());
+        for reclaimer in store.inner.reclaimers.iter() {
+            reclaimer.wait().await;
+        }
         let mut res = vec![];
         for i in 0..7 {
             res.push(store.load(&i).await.unwrap());
@@ -812,6 +815,9 @@ mod tests {
 
         // [ [e7, e3], [], [e4, e5], [e6, e1] ]
         assert!(store.enqueue(es[7].clone()).await.unwrap());
+        for reclaimer in store.inner.reclaimers.iter() {
+            reclaimer.wait().await;
+        }
         let mut res = vec![];
         for i in 0..8 {
             res.push(store.load(&i).await.unwrap());
@@ -834,6 +840,9 @@ mod tests {
         store.delete(&5).await.unwrap();
         assert!(store.enqueue(es[8].clone()).await.unwrap());
         assert!(store.enqueue(es[9].clone()).await.unwrap());
+        for reclaimer in store.inner.reclaimers.iter() {
+            reclaimer.wait().await;
+        }
         let mut res = vec![];
         for i in 0..10 {
             res.push(store.load(&i).await.unwrap());

--- a/foyer-storage/src/large/reclaimer.rs
+++ b/foyer-storage/src/large/reclaimer.rs
@@ -174,15 +174,15 @@ where
         //
         // If the loop ends on error, the subsequent indices cannot be removed while reclaiming.
         // They will be removed when a query find a mismatch entry.
-        'reclaim: loop {
+        'reinsert: loop {
             let (info, key) = match scanner.next_key().await {
-                Ok(None) => break 'reclaim,
+                Ok(None) => break 'reinsert,
                 Err(e) => {
                     tracing::warn!(
                         "[reclaimer]: Error raised when reclaiming region {id}, skip the subsequent entries, err: {e}",
                         id = region.id()
                     );
-                    break 'reclaim;
+                    break 'reinsert;
                 }
                 Ok(Some((info, key))) => (info, key),
             };
@@ -197,7 +197,7 @@ where
                             "[reclaimer]: error raised when reclaiming region {id}, skip the subsequent entries, err: {e}",
                             id = region.id()
                         );
-                        break 'reclaim;
+                        break 'reinsert;
                     }
                     Ok(buf) => buf,
                 };


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title. Wait for the reclaimers to finish a loop before lookup.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
fix #485 