### PR TITLE
feat: introduce invalid ratio picker for disk cache

### DIFF
--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -14,8 +14,8 @@
 
 use bytesize::MIB;
 use foyer::{
-    DirectFsDeviceOptionsBuilder, FifoPicker, HybridCache, HybridCacheBuilder, LfuConfig, RateLimitPicker,
-    RuntimeConfigBuilder,
+    DirectFsDeviceOptionsBuilder, FifoPicker, HybridCache, HybridCacheBuilder, InvalidRatioPicker, LfuConfig,
+    RateLimitPicker, RuntimeConfigBuilder,
 };
 use metrics_exporter_prometheus::PrometheusBuilder;
 
@@ -173,6 +173,9 @@ pub struct Args {
 
     #[arg(long, default_value_t = false)]
     flush: bool,
+
+    #[arg(long, default_value_t = 0.8)]
+    invalid_ratio: f64,
 }
 
 #[derive(Debug)]
@@ -386,7 +389,10 @@ async fn main() {
         .with_recover_concurrency(args.recover_concurrency)
         .with_flushers(args.flushers)
         .with_reclaimers(args.reclaimers)
-        .with_eviction_pickers(vec![Box::<FifoPicker>::default()])
+        .with_eviction_pickers(vec![
+            Box::new(InvalidRatioPicker::new(args.invalid_ratio)),
+            Box::<FifoPicker>::default(),
+        ])
         .with_compression(
             args.compression
                 .as_str()

--- a/foyer-storage/src/picker/mod.rs
+++ b/foyer-storage/src/picker/mod.rs
@@ -28,6 +28,10 @@ pub trait ReinsertionPicker: Send + Sync + 'static + Debug {
 }
 
 pub trait EvictionPicker: Send + Sync + 'static + Debug {
+    // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
+    #[allow(unused_variables)]
+    fn init(&mut self, regions: usize, region_size: usize) {}
+
     fn pick(&mut self, evictable: &HashMap<RegionId, Arc<RegionStats>>) -> Option<RegionId>;
 
     fn on_region_evictable(&mut self, evictable: &HashMap<RegionId, Arc<RegionStats>>, region: RegionId);

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -21,7 +21,7 @@ pub use crate::{
     },
     large::recover::RecoverMode,
     picker::{
-        utils::{AdmitAllPicker, FifoPicker, RateLimitPicker, RejectAllPicker},
+        utils::{AdmitAllPicker, FifoPicker, InvalidRatioPicker, RateLimitPicker, RejectAllPicker},
         AdmissionPicker, EvictionPicker, ReinsertionPicker,
     },
     statistics::Statistics,

--- a/foyer-storage/src/store/mod.rs
+++ b/foyer-storage/src/store/mod.rs
@@ -45,6 +45,7 @@ use crate::{
         utils::{AdmitAllPicker, RejectAllPicker},
         AdmissionPicker, EvictionPicker, ReinsertionPicker,
     },
+    FifoPicker, InvalidRatioPicker,
 };
 use noop::NoopStore;
 use runtime::{Runtime, RuntimeConfig, RuntimeStoreConfig};
@@ -288,7 +289,7 @@ where
             flushers: 1,
             reclaimers: 1,
             clean_region_threshold: None,
-            eviction_pickers: vec![],
+            eviction_pickers: vec![Box::new(InvalidRatioPicker::new(0.8)), Box::<FifoPicker>::default()],
             admision_picker: Arc::<AdmitAllPicker<K>>::default(),
             reinsertion_picker: Arc::<RejectAllPicker<K>>::default(),
             compression: Compression::None,
@@ -375,6 +376,8 @@ where
     /// will be applied.
     ///
     /// If no eviction picker pickes a region, a region will be picked randomly.
+    ///
+    /// Default: [ invalid ratio picker { threshold = 0.8 }, fifo picker ]
     pub fn with_eviction_pickers(mut self, eviction_pickers: Vec<Box<dyn EvictionPicker>>) -> Self {
         self.eviction_pickers = eviction_pickers;
         self

--- a/foyer/src/hybrid/builder.rs
+++ b/foyer/src/hybrid/builder.rs
@@ -230,6 +230,8 @@ where
     /// will be applied.
     ///
     /// If no eviction picker pickes a region, a region will be picked randomly.
+    ///
+    /// Default: [ invalid ratio picker { threshold = 0.8 }, fifo picker ]
     pub fn with_eviction_pickers(self, eviction_pickers: Vec<Box<dyn EvictionPicker>>) -> Self {
         let builder = self.builder.with_eviction_pickers(eviction_pickers);
         Self {

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -27,8 +27,8 @@ pub use memory::{CacheContext, EvictionConfig, FetchState, FifoConfig, LfuConfig
 pub use storage::{
     AdmissionPicker, AdmitAllPicker, Compression, Device, DeviceExt, DeviceOptions, DirectFileDevice,
     DirectFileDeviceOptions, DirectFileDeviceOptionsBuilder, DirectFsDevice, DirectFsDeviceOptions,
-    DirectFsDeviceOptionsBuilder, EnqueueFuture, EvictionPicker, FifoPicker, RateLimitPicker, RecoverMode,
-    ReinsertionPicker, RejectAllPicker, RuntimeConfigBuilder, Storage, Store, StoreBuilder, StoreConfig,
+    DirectFsDeviceOptionsBuilder, EnqueueFuture, EvictionPicker, FifoPicker, InvalidRatioPicker, RateLimitPicker,
+    RecoverMode, ReinsertionPicker, RejectAllPicker, RuntimeConfigBuilder, Storage, Store, StoreBuilder, StoreConfig,
     TombstoneLogConfigBuilder,
 };
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

Use invalid ratio picker + fifo picker by default.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#447 