### PR TITLE
test: introduce feature strict_assertions, which enable all assertions

### DIFF
--- a/foyer-bench/Cargo.toml
+++ b/foyer-bench/Cargo.toml
@@ -48,3 +48,4 @@ trace = [
     "tracing-opentelemetry",
     "opentelemetry-semantic-conventions",
 ]
+strict_assertions = ["foyer/strict_assertions"]

--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -26,3 +26,6 @@ tokio = { workspace = true }
 [dev-dependencies]
 futures = "0.3"
 rand = "0.8.5"
+
+[features]
+strict_assertions = []

--- a/foyer-common/src/assert.rs
+++ b/foyer-common/src/assert.rs
@@ -1,0 +1,46 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+/// Use `debug_assert!` by default. Use `assert!` when feature "strict_assertions" is enabled.
+#[macro_export]
+macro_rules! strict_assert {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "strict_assertions")]
+        assert!($($arg)*);
+        #[cfg(not(feature = "strict_assertions"))]
+        debug_assert!($($arg)*);
+    }
+}
+
+/// Use `debug_assert_eq!` by default. Use `assert_eq!` when feature "strict_assertions" is enabled.
+#[macro_export]
+macro_rules! strict_assert_eq {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "strict_assertions")]
+        assert_eq!($($arg)*);
+        #[cfg(not(feature = "strict_assertions"))]
+        debug_assert_eq!($($arg)*);
+    }
+}
+
+/// Use `debug_assert_ne!` by default. Use `assert_ne!` when feature "strict_assertions" is enabled.
+#[macro_export]
+macro_rules! strict_assert_ne {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "strict_assertions")]
+        assert_ne!($($arg)*);
+        #[cfg(not(feature = "strict_assertions"))]
+        debug_assert_ne!($($arg)*);
+    }
+}

--- a/foyer-common/src/lib.rs
+++ b/foyer-common/src/lib.rs
@@ -17,6 +17,8 @@
 
 //! Shared components and utils for foyer.
 
+/// Allow enable debug assertions in release profile with feature "strict_assertion".
+pub mod assert;
 /// A structured async batch pipeline.
 pub mod async_batch_pipeline;
 /// The util that convert the blocking call to async call.

--- a/foyer-intrusive/Cargo.toml
+++ b/foyer-intrusive/Cargo.toml
@@ -11,5 +11,9 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+foyer-common = { version = "0.7", path = "../foyer-common" }
 itertools = { workspace = true }
 memoffset = "0.9"
+
+[features]
+strict_assertions = ["foyer-common/strict_assertions"]

--- a/foyer-intrusive/src/dlist.rs
+++ b/foyer-intrusive/src/dlist.rs
@@ -16,6 +16,8 @@
 
 use std::ptr::NonNull;
 
+use foyer_common::{strict_assert, strict_assert_eq};
+
 use crate::core::{
     adapter::{Adapter, Link},
     pointer::Pointer,
@@ -227,7 +229,7 @@ where
     /// `link` MUST be in this [`Dlist`].
     pub unsafe fn remove_raw(&mut self, link: NonNull<DlistLink>) -> A::Pointer {
         let mut iter = self.iter_mut_from_raw(link);
-        debug_assert!(iter.is_valid());
+        strict_assert!(iter.is_valid());
         iter.remove().unwrap_unchecked()
     }
 
@@ -259,9 +261,9 @@ where
     ///
     /// `self` must be empty. `src` will be set empty after operation.
     pub unsafe fn replace_with(&mut self, src: &mut Dlist<A>) {
-        debug_assert!(self.head.is_none());
-        debug_assert!(self.tail.is_none());
-        debug_assert_eq!(self.len, 0);
+        strict_assert!(self.head.is_none());
+        strict_assert!(self.tail.is_none());
+        strict_assert_eq!(self.len, 0);
 
         self.head = src.head;
         self.tail = src.tail;
@@ -417,7 +419,7 @@ where
                 return None;
             }
 
-            debug_assert!(self.is_valid());
+            strict_assert!(self.is_valid());
             let mut link = self.link.unwrap_unchecked();
 
             let item = self.dlist.adapter.link2item(link);

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -34,6 +34,10 @@ zipf = "7.0.1"
 
 [features]
 deadlock = ["parking_lot/deadlock_detection"]
+strict_assertions = [
+    "foyer-common/strict_assertions",
+    "foyer-intrusive/strict_assertions",
+]
 
 [[bench]]
 name = "bench_hit_ratio"

--- a/foyer-memory/src/eviction/s3fifo.rs
+++ b/foyer-memory/src/eviction/s3fifo.rs
@@ -18,6 +18,7 @@ use std::{
     ptr::NonNull,
 };
 
+use foyer_common::{strict_assert, strict_assert_eq};
 use foyer_intrusive::{
     dlist::{Dlist, DlistLink},
     intrusive_adapter,
@@ -250,8 +251,8 @@ where
 
     unsafe fn push(&mut self, mut ptr: NonNull<Self::Handle>) {
         let handle = ptr.as_mut();
-        debug_assert_eq!(handle.freq, 0);
-        debug_assert_eq!(handle.queue, Queue::None);
+        strict_assert_eq!(handle.freq, 0);
+        strict_assert_eq!(handle.queue, Queue::None);
 
         if self.ghost_queue.contains(handle.base().hash()) {
             handle.queue = Queue::Main;
@@ -275,8 +276,8 @@ where
             handle.base_mut().set_in_eviction(false);
             Some(ptr)
         } else {
-            debug_assert!(self.small_queue.is_empty());
-            debug_assert!(self.main_queue.is_empty());
+            strict_assert!(self.small_queue.is_empty());
+            strict_assert!(self.main_queue.is_empty());
             None
         }
     }
@@ -299,7 +300,7 @@ where
                     .iter_mut_from_raw(ptr.as_mut().link.raw())
                     .remove()
                     .unwrap_unchecked();
-                debug_assert_eq!(p, ptr);
+                strict_assert_eq!(p, ptr);
 
                 handle.queue = Queue::None;
                 handle.freq = 0;
@@ -313,7 +314,7 @@ where
                     .iter_mut_from_raw(ptr.as_mut().link.raw())
                     .remove()
                     .unwrap_unchecked();
-                debug_assert_eq!(p, ptr);
+                strict_assert_eq!(p, ptr);
 
                 handle.queue = Queue::None;
                 handle.freq = 0;

--- a/foyer-memory/src/handle.rs
+++ b/foyer-memory/src/handle.rs
@@ -14,7 +14,10 @@
 
 use bitflags::bitflags;
 
-use foyer_common::code::{Key, Value};
+use foyer_common::{
+    code::{Key, Value},
+    strict_assert,
+};
 
 use crate::context::Context;
 
@@ -97,7 +100,7 @@ impl<T, C> BaseHandle<T, C> {
     /// Init handle with args.
     #[inline(always)]
     pub fn init(&mut self, hash: u64, data: T, weight: usize, context: C) {
-        debug_assert!(self.entry.is_none());
+        strict_assert!(self.entry.is_none());
         assert_ne!(weight, 0);
         self.hash = hash;
         self.entry = Some((data, context));
@@ -109,7 +112,7 @@ impl<T, C> BaseHandle<T, C> {
     /// Take key and value from the handle and reset it to the uninited state.
     #[inline(always)]
     pub fn take(&mut self) -> (T, C, usize) {
-        debug_assert!(self.entry.is_some());
+        strict_assert!(self.entry.is_some());
         unsafe {
             self.entry
                 .take()
@@ -141,7 +144,7 @@ impl<T, C> BaseHandle<T, C> {
     /// Panics if the handle is uninited.
     #[inline(always)]
     pub fn data_unwrap_unchecked(&self) -> &T {
-        debug_assert!(self.entry.is_some());
+        strict_assert!(self.entry.is_some());
         unsafe { self.entry.as_ref().map(|entry| &entry.0).unwrap_unchecked() }
     }
 
@@ -152,7 +155,7 @@ impl<T, C> BaseHandle<T, C> {
     /// Panics if the handle is uninited.
     #[inline(always)]
     pub fn context(&self) -> &C {
-        debug_assert!(self.entry.is_some());
+        strict_assert!(self.entry.is_some());
         unsafe { self.entry.as_ref().map(|entry| &entry.1).unwrap_unchecked() }
     }
 

--- a/foyer-memory/src/indexer.rs
+++ b/foyer-memory/src/indexer.rs
@@ -16,7 +16,7 @@ use std::{borrow::Borrow, hash::Hash, ptr::NonNull};
 
 use hashbrown::hash_table::{Entry as HashTableEntry, HashTable};
 
-use foyer_common::code::Key;
+use foyer_common::{code::Key, strict_assert};
 
 use crate::handle::KeyedHandle;
 
@@ -76,7 +76,7 @@ where
     unsafe fn insert(&mut self, mut ptr: NonNull<Self::Handle>) -> Option<NonNull<Self::Handle>> {
         let handle = ptr.as_mut();
 
-        debug_assert!(!handle.base().is_in_indexer());
+        strict_assert!(!handle.base().is_in_indexer());
         handle.base_mut().set_in_indexer(true);
 
         match self.table.entry(
@@ -87,7 +87,7 @@ where
             HashTableEntry::Occupied(mut o) => {
                 std::mem::swap(o.get_mut(), &mut ptr);
                 let b = ptr.as_mut().base_mut();
-                debug_assert!(b.is_in_indexer());
+                strict_assert!(b.is_in_indexer());
                 b.set_in_indexer(false);
                 Some(ptr)
             }
@@ -118,7 +118,7 @@ where
             HashTableEntry::Occupied(o) => {
                 let (mut p, _) = o.remove();
                 let b = p.as_mut().base_mut();
-                debug_assert!(b.is_in_indexer());
+                strict_assert!(b.is_in_indexer());
                 b.set_in_indexer(false);
                 Some(p)
             }

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -47,3 +47,7 @@ test-log = { workspace = true }
 default = []
 deadlock = ["parking_lot/deadlock_detection"]
 nightly = ["allocator-api2/nightly"]
+strict_assertions = [
+    "foyer-common/strict_assertions",
+    "foyer-memory/strict_assertions",
+]

--- a/foyer-storage/src/large/flusher.rs
+++ b/foyer-storage/src/large/flusher.rs
@@ -26,9 +26,9 @@ use crate::statistics::Statistics;
 use crate::Sequence;
 
 use foyer_common::async_batch_pipeline::{AsyncBatchPipeline, LeaderToken};
-use foyer_common::bits;
 use foyer_common::code::{HashBuilder, StorageKey, StorageValue};
 use foyer_common::metrics::Metrics;
+use foyer_common::{bits, strict_assert_eq};
 use foyer_memory::CacheEntry;
 use futures::future::{try_join, try_join_all};
 
@@ -275,7 +275,7 @@ where
     ) {
         tracing::trace!("[flusher]: submit tombstone with sequence: {sequence}");
 
-        debug_assert_eq!(tombstone.sequence, sequence);
+        strict_assert_eq!(tombstone.sequence, sequence);
 
         let append = |state: &mut BatchState<K, V, S, D>| {
             state.tombstones.push((tombstone, stats, tx));
@@ -384,7 +384,7 @@ where
 
     fn reinsertion(&self, mut reinsertion: Reinsertion, tx: oneshot::Sender<Result<bool>>, sequence: Sequence) {
         tracing::trace!("[flusher]: submit reinsertion with sequence: {sequence}");
-        debug_assert_eq!(sequence, 0);
+        strict_assert_eq!(sequence, 0);
 
         let append = |state: &mut BatchState<K, V, S, D>| {
             self.may_init_batch_state(state);
@@ -464,7 +464,7 @@ where
                 let mut s = BatchState::default();
                 if let Some(group) = state.groups.last() {
                     let mut writer = group.writer.clone();
-                    debug_assert_eq!(
+                    strict_assert_eq!(
                         writer.offset as usize + group.buffer.len(),
                         writer.size,
                         "offset ({offset}) + buffer len ({buf_len}) = total ({total}) != size ({size})",

--- a/foyer-storage/src/large/scanner.rs
+++ b/foyer-storage/src/large/scanner.rs
@@ -15,6 +15,7 @@
 use foyer_common::{
     bits,
     code::{StorageKey, StorageValue},
+    strict_assert, strict_assert_eq,
 };
 
 use crate::{
@@ -71,8 +72,8 @@ where
         );
         let end = std::cmp::min(self.region.size(), end);
         let read_len = end - self.offset as usize;
-        debug_assert!(bits::is_aligned(self.region.align(), read_len));
-        debug_assert!(read_len >= len);
+        strict_assert!(bits::is_aligned(self.region.align(), read_len));
+        strict_assert!(read_len >= len);
 
         let buffer = self.region.read(self.offset, read_len).await?;
         self.buffer = buffer;
@@ -107,7 +108,7 @@ where
     }
 
     async fn current(&mut self) -> Result<Option<EntryHeader>> {
-        debug_assert!(bits::is_aligned(self.region.align() as u64, self.offset));
+        strict_assert!(bits::is_aligned(self.region.align() as u64, self.offset));
 
         if self.offset as usize >= self.region.size() {
             // reach region EOF
@@ -215,7 +216,7 @@ where
 
         let buf = self.cache.read(info.addr.offset as _, info.addr.len as _).await?;
         let (h, key, value) = EntryDeserializer::deserialize(buf)?;
-        debug_assert_eq!(header, h);
+        strict_assert_eq!(header, h);
 
         self.step(&header).await;
 

--- a/foyer-storage/src/picker/utils.rs
+++ b/foyer-storage/src/picker/utils.rs
@@ -22,7 +22,7 @@ use std::{
     },
 };
 
-use foyer_common::{code::StorageKey, rated_ticket::RatedTicket};
+use foyer_common::{code::StorageKey, rated_ticket::RatedTicket, strict_assert};
 use itertools::Itertools;
 
 use crate::{device::RegionId, region::RegionStats, statistics::Statistics};
@@ -244,7 +244,7 @@ impl EvictionPicker for InvalidRatioPicker {
     }
 
     fn pick(&mut self, evictable: &HashMap<RegionId, Arc<RegionStats>>) -> Option<RegionId> {
-        debug_assert!(self.region_size > 0);
+        strict_assert!(self.region_size > 0);
 
         let mut info = evictable
             .iter()

--- a/foyer-storage/src/tombstone.rs
+++ b/foyer-storage/src/tombstone.rs
@@ -19,7 +19,7 @@ use std::{
 
 use array_util::SliceExt;
 use bytes::{Buf, BufMut};
-use foyer_common::{bits, metrics::Metrics};
+use foyer_common::{bits, metrics::Metrics, strict_assert_eq};
 use futures::future::try_join_all;
 use tokio::sync::Mutex;
 
@@ -269,8 +269,8 @@ where
             )
             .await?;
 
-        debug_assert_eq!(self.buffer.len(), self.device.align());
-        debug_assert_eq!(self.buffer.capacity(), self.device.align());
+        strict_assert_eq!(self.buffer.len(), self.device.align());
+        strict_assert_eq!(self.buffer.capacity(), self.device.align());
 
         Ok(())
     }

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.76"
 ahash = "0.8"
 anyhow = "1"
 foyer-common = { version = "0.7", path = "../foyer-common" }
-foyer-intrusive = { version = "0.6", path = "../foyer-intrusive" }
 foyer-memory = { version = "0.4", path = "../foyer-memory" }
 foyer-storage = { version = "0.8", path = "../foyer-storage" }
 tokio = { workspace = true }
@@ -29,3 +28,8 @@ test-log = { workspace = true }
 default = []
 nightly = ["foyer-storage/nightly"]
 deadlock = ["foyer-storage/deadlock"]
+strict_assertions = [
+    "foyer-common/strict_assertions",
+    "foyer-memory/strict_assertions",
+    "foyer-storage/strict_assertions",
+]


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

The new macro family `strict_assert!` behaves like `debug_assert!` by default, and behaves like `assert!` when feature `strict_assertions` is enabled.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#525 