### PR TITLE
refactor: replace memoffset::offset_of with std::mem::offset_of

### DIFF
--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        rust_toolchain: [stable, 1.76]
+        rust_toolchain: [stable, 1.77]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        rust_toolchain: [stable, 1.76]
+        rust_toolchain: [stable, 1.77]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        rust_toolchain: [stable, 1.76]
+        rust_toolchain: [stable, 1.77]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -51,15 +51,15 @@ msrv:
 	shellcheck ./scripts/*
 	./.github/template/generate.sh
 	./scripts/minimize-dashboards.sh
-	cargo +1.76 sort -w
-	cargo +1.76 fmt --all
-	cargo +1.76 clippy --all-targets --features deadlock
-	cargo +1.76 clippy --all-targets --features tokio-console
-	cargo +1.76 clippy --all-targets --features trace
-	cargo +1.76 clippy --all-targets
-	RUST_BACKTRACE=1 cargo +1.76 nextest run --all
-	RUST_BACKTRACE=1 cargo +1.76 test --doc
-	RUST_BACKTRACE=1 cargo +1.76 nextest run --run-ignored ignored-only --no-capture --workspace
+	cargo +1.77 sort -w
+	cargo +1.77 fmt --all
+	cargo +1.77 clippy --all-targets --features deadlock
+	cargo +1.77 clippy --all-targets --features tokio-console
+	cargo +1.77 clippy --all-targets --features trace
+	cargo +1.77 clippy --all-targets
+	RUST_BACKTRACE=1 cargo +1.77 nextest run --all
+	RUST_BACKTRACE=1 cargo +1.77 test --doc
+	RUST_BACKTRACE=1 cargo +1.77 nextest run --run-ignored ignored-only --no-capture --workspace
 
 udeps:
 	RUSTFLAGS="--cfg tokio_unstable -Awarnings" cargo +nightly-2024-03-17 udeps --all-targets

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ More examples and details can be found [here](https://github.com/MrCroxx/foyer/t
 
 ## Supported Rust Versions
 
-*foyer* is built against the recent stable release. The minimum supported version is 1.76. The current *foyer* version is not guaranteed to build on Rust versions earlier than the minimum supported version.
+*foyer* is built against the recent stable release. The minimum supported version is 1.77. The current *foyer* version is not guaranteed to build on Rust versions earlier than the minimum supported version.
 
 ## Development state & Roadmap
 

--- a/foyer-intrusive/Cargo.toml
+++ b/foyer-intrusive/Cargo.toml
@@ -13,7 +13,6 @@ readme = "../README.md"
 [dependencies]
 foyer-common = { version = "0.7", path = "../foyer-common" }
 itertools = { workspace = true }
-memoffset = "0.9"
 
 [features]
 strict_assertions = ["foyer-common/strict_assertions"]

--- a/foyer-intrusive/src/core/adapter.rs
+++ b/foyer-intrusive/src/core/adapter.rs
@@ -139,7 +139,7 @@ macro_rules! intrusive_adapter {
                 &self,
                 item: std::ptr::NonNull<<Self::Pointer as $crate::core::pointer::Pointer>::Item>,
             ) -> std::ptr::NonNull<Self::Link> {
-                std::ptr::NonNull::new_unchecked((item.as_ptr() as *mut u8).add($crate::offset_of!($item, $field)) as *mut Self::Link)
+                std::ptr::NonNull::new_unchecked((item.as_ptr() as *mut u8).add(std::mem::offset_of!($item, $field)) as *mut Self::Link)
             }
         }
 

--- a/foyer-intrusive/src/dlist.rs
+++ b/foyer-intrusive/src/dlist.rs
@@ -617,7 +617,7 @@ mod tests {
         }
 
         unsafe fn item2link(&self, item: NonNull<<Self::Pointer as Pointer>::Item>) -> NonNull<Self::Link> {
-            NonNull::new_unchecked((item.as_ptr() as *const u8).add(crate::offset_of!(DlistItem, link)) as *mut _)
+            NonNull::new_unchecked((item.as_ptr() as *const u8).add(std::mem::offset_of!(DlistItem, link)) as *mut _)
         }
     }
 

--- a/foyer-intrusive/src/lib.rs
+++ b/foyer-intrusive/src/lib.rs
@@ -18,8 +18,6 @@
 
 //! Intrusive data structures and utils for foyer.
 
-pub use memoffset::offset_of;
-
 /// Unsafe macro to get a raw pointer to an outer object from a pointer to one
 /// of its fields.
 ///
@@ -42,7 +40,7 @@ pub use memoffset::offset_of;
 #[macro_export]
 macro_rules! container_of {
     ($ptr:expr, $container:path, $field:ident) => {
-        ($ptr as *const _ as *const u8).sub($crate::offset_of!($container, $field)) as *const $container
+        ($ptr as *const _ as *const u8).sub(std::mem::offset_of!($container, $field)) as *const $container
     };
 }
 

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -28,7 +28,6 @@ futures = "0.3"
 itertools = { workspace = true }
 lazy_static = "1"
 lz4 = "1.24"
-memoffset = "0.9"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 pin-project = "1"
 rand = "0.8"

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mrcroxx/foyer"
 homepage = "https://github.com/mrcroxx/foyer"
 readme = "../README.md"
-rust-version = "1.76"
+rust-version = "1.77"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title. Besides, promote MSRV to 1.77.0 

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
