### PR TITLE
feat: introduce sanity check for indexer and eviction

### DIFF
--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -124,13 +124,13 @@ jobs:
           RUST_BACKTRACE: 1
           CI: true
         run: |
-          cargo llvm-cov --no-report nextest --run-ignored ignored-only --no-capture --workspace
+          cargo llvm-cov --no-report nextest --run-ignored ignored-only --no-capture --workspace --features "strict_assertions,sanity"
       - name: Run rust test with coverage
         env:
           RUST_BACKTRACE: 1
           CI: true
         run: |
-          cargo llvm-cov --no-report nextest
+          cargo llvm-cov --no-report nextest --features "strict_assertions,sanity"
       - name: Run examples with coverage
         env:
           RUST_BACKTRACE: 1
@@ -146,7 +146,7 @@ jobs:
           CI: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov
-          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench --features "strict_assertions,sanity" -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Generate codecov report
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,13 +130,13 @@ jobs:
           RUST_BACKTRACE: 1
           CI: true
         run: |
-          cargo llvm-cov --no-report nextest --run-ignored ignored-only --no-capture --workspace
+          cargo llvm-cov --no-report nextest --run-ignored ignored-only --no-capture --workspace --features "strict_assertions,sanity"
       - name: Run rust test with coverage
         env:
           RUST_BACKTRACE: 1
           CI: true
         run: |
-          cargo llvm-cov --no-report nextest
+          cargo llvm-cov --no-report nextest --features "strict_assertions,sanity"
       - name: Run examples with coverage
         env:
           RUST_BACKTRACE: 1
@@ -152,7 +152,7 @@ jobs:
           CI: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov
-          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench --features "strict_assertions,sanity" -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Generate codecov report
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -129,13 +129,13 @@ jobs:
           RUST_BACKTRACE: 1
           CI: true
         run: |
-          cargo llvm-cov --no-report nextest --run-ignored ignored-only --no-capture --workspace
+          cargo llvm-cov --no-report nextest --run-ignored ignored-only --no-capture --workspace --features "strict_assertions,sanity"
       - name: Run rust test with coverage
         env:
           RUST_BACKTRACE: 1
           CI: true
         run: |
-          cargo llvm-cov --no-report nextest
+          cargo llvm-cov --no-report nextest --features "strict_assertions,sanity"
       - name: Run examples with coverage
         env:
           RUST_BACKTRACE: 1
@@ -151,7 +151,7 @@ jobs:
           CI: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov
-          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench --features "strict_assertions,sanity" -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Generate codecov report
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,15 @@ check-all:
 	cargo clippy --all-targets --features deadlock
 	cargo clippy --all-targets --features tokio-console
 	cargo clippy --all-targets --features trace
-	cargo clippy --all-targets --features strict_assertions
+	cargo clippy --all-targets --features sanity
+	cargo clippy --all-targets
 
 test:
-	RUST_BACKTRACE=1 cargo nextest run --all --features strict_assertions
+	RUST_BACKTRACE=1 cargo nextest run --all --features "strict_assertions,sanity"
 	RUST_BACKTRACE=1 cargo test --doc
 
 test-ignored:
-	RUST_BACKTRACE=1 cargo nextest run --run-ignored ignored-only --no-capture --workspace --features strict_assertions
+	RUST_BACKTRACE=1 cargo nextest run --run-ignored ignored-only --no-capture --workspace --features "strict_assertions,sanity"
 
 test-all: test test-ignored
 

--- a/foyer-bench/Cargo.toml
+++ b/foyer-bench/Cargo.toml
@@ -49,3 +49,4 @@ trace = [
     "opentelemetry-semantic-conventions",
 ]
 strict_assertions = ["foyer/strict_assertions"]
+sanity = ["foyer/sanity"]

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -39,6 +39,7 @@ strict_assertions = [
     "foyer-common/strict_assertions",
     "foyer-intrusive/strict_assertions",
 ]
+sanity = ["strict_assertions"]
 
 [[bench]]
 name = "bench_hit_ratio"

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -28,37 +28,45 @@ use crate::{
         lfu::{Lfu, LfuHandle},
         lru::{Lru, LruHandle},
         s3fifo::{S3Fifo, S3FifoHandle},
+        sanity::SanityEviction,
     },
     generic::{GenericCache, GenericCacheConfig, GenericCacheEntry, GenericFetch, Weighter},
-    indexer::HashTableIndexer,
+    indexer::{hash_table::HashTableIndexer, sanity::SanityIndexer},
     FifoConfig, LfuConfig, LruConfig, S3FifoConfig,
 };
 
 pub type FifoCache<K, V, S = RandomState> =
-    GenericCache<K, V, Fifo<(K, V)>, HashTableIndexer<K, FifoHandle<(K, V)>>, S>;
+    GenericCache<K, V, SanityEviction<Fifo<(K, V)>>, SanityIndexer<HashTableIndexer<K, FifoHandle<(K, V)>>>, S>;
 pub type FifoCacheEntry<K, V, S = RandomState> =
-    GenericCacheEntry<K, V, Fifo<(K, V)>, HashTableIndexer<K, FifoHandle<(K, V)>>, S>;
+    GenericCacheEntry<K, V, SanityEviction<Fifo<(K, V)>>, SanityIndexer<HashTableIndexer<K, FifoHandle<(K, V)>>>, S>;
 pub type FifoFetch<K, V, ER, S = RandomState> =
-    GenericFetch<K, V, Fifo<(K, V)>, HashTableIndexer<K, FifoHandle<(K, V)>>, S, ER>;
+    GenericFetch<K, V, SanityEviction<Fifo<(K, V)>>, SanityIndexer<HashTableIndexer<K, FifoHandle<(K, V)>>>, S, ER>;
 
-pub type LruCache<K, V, S = RandomState> = GenericCache<K, V, Lru<(K, V)>, HashTableIndexer<K, LruHandle<(K, V)>>, S>;
+pub type LruCache<K, V, S = RandomState> =
+    GenericCache<K, V, SanityEviction<Lru<(K, V)>>, SanityIndexer<HashTableIndexer<K, LruHandle<(K, V)>>>, S>;
 pub type LruCacheEntry<K, V, S = RandomState> =
-    GenericCacheEntry<K, V, Lru<(K, V)>, HashTableIndexer<K, LruHandle<(K, V)>>, S>;
+    GenericCacheEntry<K, V, SanityEviction<Lru<(K, V)>>, SanityIndexer<HashTableIndexer<K, LruHandle<(K, V)>>>, S>;
 pub type LruFetch<K, V, ER, S = RandomState> =
-    GenericFetch<K, V, Lru<(K, V)>, HashTableIndexer<K, LruHandle<(K, V)>>, S, ER>;
+    GenericFetch<K, V, SanityEviction<Lru<(K, V)>>, SanityIndexer<HashTableIndexer<K, LruHandle<(K, V)>>>, S, ER>;
 
-pub type LfuCache<K, V, S = RandomState> = GenericCache<K, V, Lfu<(K, V)>, HashTableIndexer<K, LfuHandle<(K, V)>>, S>;
+pub type LfuCache<K, V, S = RandomState> =
+    GenericCache<K, V, SanityEviction<Lfu<(K, V)>>, SanityIndexer<HashTableIndexer<K, LfuHandle<(K, V)>>>, S>;
 pub type LfuCacheEntry<K, V, S = RandomState> =
-    GenericCacheEntry<K, V, Lfu<(K, V)>, HashTableIndexer<K, LfuHandle<(K, V)>>, S>;
+    GenericCacheEntry<K, V, SanityEviction<Lfu<(K, V)>>, SanityIndexer<HashTableIndexer<K, LfuHandle<(K, V)>>>, S>;
 pub type LfuFetch<K, V, ER, S = RandomState> =
-    GenericFetch<K, V, Lfu<(K, V)>, HashTableIndexer<K, LfuHandle<(K, V)>>, S, ER>;
+    GenericFetch<K, V, SanityEviction<Lfu<(K, V)>>, SanityIndexer<HashTableIndexer<K, LfuHandle<(K, V)>>>, S, ER>;
 
 pub type S3FifoCache<K, V, S = RandomState> =
-    GenericCache<K, V, S3Fifo<(K, V)>, HashTableIndexer<K, S3FifoHandle<(K, V)>>, S>;
-pub type S3FifoCacheEntry<K, V, S = RandomState> =
-    GenericCacheEntry<K, V, S3Fifo<(K, V)>, HashTableIndexer<K, S3FifoHandle<(K, V)>>, S>;
+    GenericCache<K, V, SanityEviction<S3Fifo<(K, V)>>, SanityIndexer<HashTableIndexer<K, S3FifoHandle<(K, V)>>>, S>;
+pub type S3FifoCacheEntry<K, V, S = RandomState> = GenericCacheEntry<
+    K,
+    V,
+    SanityEviction<S3Fifo<(K, V)>>,
+    SanityIndexer<HashTableIndexer<K, S3FifoHandle<(K, V)>>>,
+    S,
+>;
 pub type S3FifoFetch<K, V, ER, S = RandomState> =
-    GenericFetch<K, V, S3Fifo<(K, V)>, HashTableIndexer<K, S3FifoHandle<(K, V)>>, S, ER>;
+    GenericFetch<K, V, SanityEviction<S3Fifo<(K, V)>>, SanityIndexer<HashTableIndexer<K, S3FifoHandle<(K, V)>>>, S, ER>;
 
 /// A cached entry holder of the in-memory cache.
 #[derive(Debug)]

--- a/foyer-memory/src/eviction/mod.rs
+++ b/foyer-memory/src/eviction/mod.rs
@@ -16,6 +16,8 @@ use std::ptr::NonNull;
 
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::handle::Handle;
+
 pub trait EvictionConfig: Send + Sync + 'static + Clone + Serialize + DeserializeOwned + Default {}
 impl<T> EvictionConfig for T where T: Send + Sync + 'static + Clone + Serialize + DeserializeOwned + Default {}
 
@@ -23,7 +25,7 @@ impl<T> EvictionConfig for T where T: Send + Sync + 'static + Clone + Serialize 
 ///
 /// Each `handle`'s lifetime in [`Indexer`] must outlive the raw pointer in [`Eviction`].
 pub trait Eviction: Send + Sync + 'static {
-    type Handle;
+    type Handle: Handle;
     type Config: EvictionConfig;
 
     /// Create a new empty eviction container.
@@ -99,6 +101,8 @@ pub mod fifo;
 pub mod lfu;
 pub mod lru;
 pub mod s3fifo;
+
+pub mod sanity;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/foyer-memory/src/eviction/sanity.rs
+++ b/foyer-memory/src/eviction/sanity.rs
@@ -1,0 +1,150 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#[cfg(feature = "sanity")]
+use crate::handle::Handle;
+
+use super::Eviction;
+
+pub struct SanityEviction<E>
+where
+    E: Eviction,
+{
+    eviction: E,
+}
+
+#[cfg(feature = "sanity")]
+impl<E> Eviction for SanityEviction<E>
+where
+    E: Eviction,
+{
+    type Handle = E::Handle;
+    type Config = E::Config;
+
+    unsafe fn new(capacity: usize, config: &Self::Config) -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            eviction: E::new(capacity, config),
+        }
+    }
+
+    unsafe fn push(&mut self, ptr: std::ptr::NonNull<Self::Handle>) {
+        assert!(!ptr.as_ref().base().is_in_eviction());
+        self.eviction.push(ptr);
+        assert!(ptr.as_ref().base().is_in_eviction());
+    }
+
+    unsafe fn pop(&mut self) -> Option<std::ptr::NonNull<Self::Handle>> {
+        let res = self.eviction.pop();
+        if let Some(ptr) = res {
+            assert!(!ptr.as_ref().base().is_in_eviction());
+        }
+        res
+    }
+
+    unsafe fn acquire(&mut self, ptr: std::ptr::NonNull<Self::Handle>) {
+        self.eviction.acquire(ptr)
+    }
+
+    unsafe fn release(&mut self, ptr: std::ptr::NonNull<Self::Handle>) {
+        self.eviction.release(ptr)
+    }
+
+    unsafe fn remove(&mut self, ptr: std::ptr::NonNull<Self::Handle>) {
+        assert!(ptr.as_ref().base().is_in_eviction());
+        self.eviction.remove(ptr);
+        assert!(!ptr.as_ref().base().is_in_eviction());
+    }
+
+    unsafe fn clear(&mut self) -> Vec<std::ptr::NonNull<Self::Handle>> {
+        self.eviction.clear()
+    }
+
+    fn len(&self) -> usize {
+        self.eviction.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.eviction.is_empty()
+    }
+}
+
+#[cfg(not(feature = "sanity"))]
+impl<E> Eviction for SanityEviction<E>
+where
+    E: Eviction,
+{
+    type Handle = E::Handle;
+    type Config = E::Config;
+
+    unsafe fn new(capacity: usize, config: &Self::Config) -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            eviction: E::new(capacity, config),
+        }
+    }
+
+    unsafe fn push(&mut self, ptr: std::ptr::NonNull<Self::Handle>) {
+        self.eviction.push(ptr)
+    }
+
+    unsafe fn pop(&mut self) -> Option<std::ptr::NonNull<Self::Handle>> {
+        self.eviction.pop()
+    }
+
+    unsafe fn acquire(&mut self, ptr: std::ptr::NonNull<Self::Handle>) {
+        self.eviction.acquire(ptr)
+    }
+
+    unsafe fn release(&mut self, ptr: std::ptr::NonNull<Self::Handle>) {
+        self.eviction.release(ptr)
+    }
+
+    unsafe fn remove(&mut self, ptr: std::ptr::NonNull<Self::Handle>) {
+        self.eviction.remove(ptr)
+    }
+
+    unsafe fn clear(&mut self) -> Vec<std::ptr::NonNull<Self::Handle>> {
+        self.eviction.clear()
+    }
+
+    fn len(&self) -> usize {
+        self.eviction.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.eviction.is_empty()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::{eviction::test_utils::TestEviction, handle::Handle};
+
+    impl<T, E> TestEviction for SanityEviction<E>
+    where
+        T: Send + Sync + 'static + Clone,
+        E: TestEviction,
+        E::Handle: Handle<Data = T>,
+    {
+        fn dump(&self) -> Vec<T> {
+            self.eviction.dump()
+        }
+    }
+}

--- a/foyer-memory/src/generic.rs
+++ b/foyer-memory/src/generic.rs
@@ -957,7 +957,7 @@ mod tests {
             lru::LruConfig,
             test_utils::TestEviction,
         },
-        indexer::HashTableIndexer,
+        indexer::{hash_table::HashTableIndexer, sanity::SanityIndexer},
         LfuConfig, S3FifoConfig,
     };
 
@@ -971,7 +971,7 @@ mod tests {
 
     // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
     #[allow(clippy::type_complexity)]
-    fn fuzzy<E>(cache: Arc<GenericCache<u64, u64, E, HashTableIndexer<u64, E::Handle>>>)
+    fn fuzzy<E>(cache: Arc<GenericCache<u64, u64, E, SanityIndexer<HashTableIndexer<u64, E::Handle>>>>)
     where
         E: Eviction,
         E::Handle: KeyedHandle<Key = u64, Data = (u64, u64)>,

--- a/foyer-memory/src/indexer/hash_table.rs
+++ b/foyer-memory/src/indexer/hash_table.rs
@@ -20,22 +20,7 @@ use foyer_common::{code::Key, strict_assert};
 
 use crate::handle::KeyedHandle;
 
-pub trait Indexer: Send + Sync + 'static {
-    type Key: Key;
-    type Handle: KeyedHandle<Key = Self::Key>;
-
-    fn new() -> Self;
-    unsafe fn insert(&mut self, handle: NonNull<Self::Handle>) -> Option<NonNull<Self::Handle>>;
-    unsafe fn get<Q>(&self, hash: u64, key: &Q) -> Option<NonNull<Self::Handle>>
-    where
-        Self::Key: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
-    unsafe fn remove<Q>(&mut self, hash: u64, key: &Q) -> Option<NonNull<Self::Handle>>
-    where
-        Self::Key: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
-    unsafe fn drain(&mut self) -> impl Iterator<Item = NonNull<Self::Handle>>;
-}
+use super::Indexer;
 
 pub struct HashTableIndexer<K, H>
 where

--- a/foyer-memory/src/indexer/mod.rs
+++ b/foyer-memory/src/indexer/mod.rs
@@ -1,0 +1,39 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::{borrow::Borrow, hash::Hash, ptr::NonNull};
+
+use foyer_common::code::Key;
+
+use crate::handle::KeyedHandle;
+
+pub trait Indexer: Send + Sync + 'static {
+    type Key: Key;
+    type Handle: KeyedHandle<Key = Self::Key>;
+
+    fn new() -> Self;
+    unsafe fn insert(&mut self, ptr: NonNull<Self::Handle>) -> Option<NonNull<Self::Handle>>;
+    unsafe fn get<Q>(&self, hash: u64, key: &Q) -> Option<NonNull<Self::Handle>>
+    where
+        Self::Key: Borrow<Q>,
+        Q: Hash + Eq + ?Sized;
+    unsafe fn remove<Q>(&mut self, hash: u64, key: &Q) -> Option<NonNull<Self::Handle>>
+    where
+        Self::Key: Borrow<Q>,
+        Q: Hash + Eq + ?Sized;
+    unsafe fn drain(&mut self) -> impl Iterator<Item = NonNull<Self::Handle>>;
+}
+
+pub mod hash_table;
+pub mod sanity;

--- a/foyer-memory/src/indexer/sanity.rs
+++ b/foyer-memory/src/indexer/sanity.rs
@@ -1,0 +1,136 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::ptr::NonNull;
+
+#[cfg(feature = "sanity")]
+use crate::handle::Handle;
+
+use super::Indexer;
+
+pub struct SanityIndexer<I>
+where
+    I: Indexer,
+{
+    indexer: I,
+}
+
+#[cfg(feature = "sanity")]
+impl<I> Indexer for SanityIndexer<I>
+where
+    I: Indexer,
+{
+    type Key = I::Key;
+    type Handle = I::Handle;
+
+    fn new() -> Self {
+        Self { indexer: I::new() }
+    }
+
+    unsafe fn insert(&mut self, ptr: NonNull<Self::Handle>) -> Option<NonNull<Self::Handle>> {
+        assert!(!ptr.as_ref().base().is_in_indexer());
+        let res = self
+            .indexer
+            .insert(ptr)
+            .inspect(|old| assert!(!old.as_ref().base().is_in_indexer()));
+        assert!(ptr.as_ref().base().is_in_indexer());
+        res
+    }
+
+    unsafe fn get<Q>(&self, hash: u64, key: &Q) -> Option<NonNull<Self::Handle>>
+    where
+        Self::Key: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.indexer
+            .get(hash, key)
+            .inspect(|ptr| assert!(ptr.as_ref().base().is_in_indexer()))
+    }
+
+    unsafe fn remove<Q>(&mut self, hash: u64, key: &Q) -> Option<NonNull<Self::Handle>>
+    where
+        Self::Key: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.indexer
+            .remove(hash, key)
+            .inspect(|ptr| assert!(!ptr.as_ref().base().is_in_indexer()))
+    }
+
+    unsafe fn drain(&mut self) -> impl Iterator<Item = NonNull<Self::Handle>> {
+        self.indexer.drain()
+    }
+}
+
+#[cfg(feature = "sanity")]
+pub struct SanityIndexerDrain<I, IT>
+where
+    I: Indexer,
+    IT: Iterator<Item = NonNull<I::Handle>>,
+{
+    iterator: IT,
+    _marker: std::marker::PhantomData<I>,
+}
+
+#[cfg(feature = "sanity")]
+impl<I, IT> Iterator for SanityIndexerDrain<I, IT>
+where
+    I: Indexer,
+    IT: Iterator<Item = NonNull<I::Handle>>,
+{
+    type Item = IT::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iterator
+            .next()
+            .inspect(|ptr| unsafe { assert!(ptr.as_ref().base().is_in_indexer()) })
+    }
+}
+
+#[cfg(not(feature = "sanity"))]
+impl<I> Indexer for SanityIndexer<I>
+where
+    I: Indexer,
+{
+    type Key = I::Key;
+    type Handle = I::Handle;
+
+    fn new() -> Self {
+        Self { indexer: I::new() }
+    }
+
+    unsafe fn insert(&mut self, handle: NonNull<Self::Handle>) -> Option<NonNull<Self::Handle>> {
+        self.indexer.insert(handle)
+    }
+
+    unsafe fn get<Q>(&self, hash: u64, key: &Q) -> Option<NonNull<Self::Handle>>
+    where
+        Self::Key: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.indexer.get(hash, key)
+    }
+
+    unsafe fn remove<Q>(&mut self, hash: u64, key: &Q) -> Option<NonNull<Self::Handle>>
+    where
+        Self::Key: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.indexer.remove(hash, key)
+    }
+
+    unsafe fn drain(&mut self) -> impl Iterator<Item = NonNull<Self::Handle>> {
+        self.indexer.drain()
+    }
+}

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -33,3 +33,4 @@ strict_assertions = [
     "foyer-memory/strict_assertions",
     "foyer-storage/strict_assertions",
 ]
+sanity = ["strict_assertions", "foyer-memory/sanity"]


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title. With feature `sanity` enabled, both `strict_assertions` and `sanity` will be used to strictly check the implementation.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#531 