### PR TITLE
fix: check if entry is in indexer first before remove for deposit

### DIFF
--- a/foyer-memory/src/generic.rs
+++ b/foyer-memory/src/generic.rs
@@ -319,7 +319,7 @@ where
         strict_assert!(handle.base().is_inited());
         strict_assert!(!handle.base().has_refs());
 
-        if handle.base().is_deposit() {
+        if handle.base().is_in_indexer() && handle.base().is_deposit() {
             strict_assert!(!handle.base().is_in_eviction());
             self.indexer.remove(handle.base().hash(), handle.key());
             strict_assert!(!handle.base().is_in_indexer());
@@ -1074,6 +1074,17 @@ mod tests {
         drop(e);
         assert_eq!(cache.usage(), 6);
         assert_eq!(cache.get(&42).unwrap().value(), "answer");
+    }
+
+    #[test]
+    fn test_deposit_replace() {
+        let cache = lru(100);
+        let e1 = cache.deposit(42, "wrong answer".to_string());
+        let e2 = cache.insert(42, "answer".to_string());
+        drop(e1);
+        drop(e2);
+        assert_eq!(cache.get(&42).unwrap().value(), "answer");
+        assert_eq!(cache.usage(), 6);
     }
 
     #[test]

--- a/foyer-memory/src/generic.rs
+++ b/foyer-memory/src/generic.rs
@@ -319,6 +319,7 @@ where
         strict_assert!(handle.base().is_inited());
         strict_assert!(!handle.base().has_refs());
 
+        // If the entry is depoist (emplace by deposit & never read), remove it from indexer to skip reinsertion.
         if handle.base().is_in_indexer() && handle.base().is_deposit() {
             strict_assert!(!handle.base().is_in_eviction());
             self.indexer.remove(handle.base().hash(), handle.key());
@@ -335,6 +336,7 @@ where
                 let was_in_eviction = handle.base().is_in_eviction();
                 self.eviction.release(ptr);
                 if ptr.as_ref().base().is_in_eviction() {
+                    // The entry is not yep evicted, do NOT release it.
                     if !was_in_eviction {
                         self.state.metrics.memory_reinsert.increment(1);
                     }

--- a/foyer-memory/src/generic.rs
+++ b/foyer-memory/src/generic.rs
@@ -319,7 +319,7 @@ where
         strict_assert!(handle.base().is_inited());
         strict_assert!(!handle.base().has_refs());
 
-        // If the entry is depoist (emplace by deposit & never read), remove it from indexer to skip reinsertion.
+        // If the entry is deposit (emplace by deposit & never read), remove it from indexer to skip reinsertion.
         if handle.base().is_in_indexer() && handle.base().is_deposit() {
             strict_assert!(!handle.base().is_in_eviction());
             self.indexer.remove(handle.base().hash(), handle.key());


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Previously, when a deposit entry is released after no external reference, it will remove the key from the indexer without checking if the entry is still in it. When there is another insertion with the same key between a deposit entry is inserted and released, this behavior will mistakenly delete the new version of the key from the indexer. Then the new entry is not in the indexer but maybe in the eviction container, which breaks the assumptions and cause panic.

```rust
- if handle.base().is_deposit() {
+ if handle.base().is_in_indexer() && handle.base().is_deposit() {
```

To reproduce:

```rust
    #[test]
    fn test_deposit_replace() {
        let cache = lru(100);
        let e1 = cache.deposit(42, "wrong answer".to_string());
        let e2 = cache.insert(42, "answer".to_string());
        drop(e1);
        drop(e2);
        assert_eq!(cache.get(&42).unwrap().value(), "answer");
        assert_eq!(cache.usage(), 6);
    }
```

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
fix #531 
fix #525 
https://github.com/risingwavelabs/risingwave/pull/16869