### PR TITLE
fix: use libc::O_DIRECT for multi target/os/arch

### DIFF
--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -27,6 +27,7 @@ foyer-memory = { version = "0.5", path = "../foyer-memory" }
 futures = "0.3"
 itertools = { workspace = true }
 lazy_static = "1"
+libc = "0.2"
 lz4 = "1.24"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 pin-project = "1"

--- a/foyer-storage/src/device/direct_file.rs
+++ b/foyer-storage/src/device/direct_file.rs
@@ -72,11 +72,6 @@ impl DeviceOptions for DirectFileDeviceOptions {
 }
 
 impl DirectFileDevice {
-    #[cfg(target_os = "linux")]
-    const O_DIRECT: i32 = 0x4000;
-}
-
-impl DirectFileDevice {
     /// Positioned write API for the direct file device.
     pub async fn pwrite(&self, mut buf: IoBuffer, offset: u64) -> Result<()> {
         bits::assert_aligned(self.align() as u64, offset);
@@ -177,7 +172,7 @@ impl Device for DirectFileDevice {
         #[cfg(target_os = "linux")]
         {
             use std::os::unix::fs::OpenOptionsExt;
-            opts.custom_flags(Self::O_DIRECT);
+            opts.custom_flags(libc::O_DIRECT);
         }
 
         let file = opts.open(&options.path)?;

--- a/foyer-storage/src/device/direct_fs.rs
+++ b/foyer-storage/src/device/direct_fs.rs
@@ -82,9 +82,6 @@ impl DeviceOptions for DirectFsDeviceOptions {
 impl DirectFsDevice {
     const PREFIX: &'static str = "foyer-storage-direct-fs-";
 
-    #[cfg(target_os = "linux")]
-    const O_DIRECT: i32 = 0x4000;
-
     fn filename(region: RegionId) -> String {
         format!("{}{:08}", Self::PREFIX, region)
     }
@@ -128,7 +125,7 @@ impl Device for DirectFsDevice {
                     #[cfg(target_os = "linux")]
                     {
                         use std::os::unix::fs::OpenOptionsExt;
-                        opts.custom_flags(Self::O_DIRECT);
+                        opts.custom_flags(libc::O_DIRECT);
                     }
 
                     let file = opts.open(path)?;


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title. `O_DIRECT` value differs on different platforms.

```rust
// linux amd64
pub const O_DIRECT: ::c_int = 0x4000;
// linux aarch64
pub const O_DIRECT: ::c_int = 0x10000;
```

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#555