### PR TITLE
perf: impl tail-based tracing with minitrace

### DIFF
--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -114,6 +114,7 @@ jobs:
         run: |
           cargo clippy --all-targets --features tokio-console -- -D warnings
           cargo clippy --all-targets --features deadlock -- -D warnings
+          cargo clippy --all-targets --features mtrace -- -D warnings
           cargo clippy --all-targets -- -D warnings
       - if: steps.cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,7 @@ jobs:
         run: |
           cargo clippy --all-targets --features tokio-console -- -D warnings
           cargo clippy --all-targets --features deadlock -- -D warnings
+          cargo clippy --all-targets --features mtrace -- -D warnings
           cargo clippy --all-targets -- -D warnings
       - if: steps.cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -119,6 +119,7 @@ jobs:
         run: |
           cargo clippy --all-targets --features tokio-console -- -D warnings
           cargo clippy --all-targets --features deadlock -- -D warnings
+          cargo clippy --all-targets --features mtrace -- -D warnings
           cargo clippy --all-targets -- -D warnings
       - if: steps.cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ docker-compose.override.yaml
 
 perf.data*
 flamegraph.svg
+
+trace.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ test-log = { version = "0.2", default-features = false, features = [
 ] }
 itertools = "0.13"
 metrics = "0.23"
+minitrace = "0.6"
+minitrace-jaeger = "0.6"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,5 @@ metrics = "0.23"
 minitrace = "0.6"
 minitrace-jaeger = "0.6"
 
-
 [profile.release]
 debug = true
-
-# [patch.crates-io]
-# minitrace = { path = "../minitrace-rust/minitrace" }
-# minitrace-jaeger = { path = "../minitrace-rust/minitrace-jaeger" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,10 @@ metrics = "0.23"
 minitrace = "0.6"
 minitrace-jaeger = "0.6"
 
+
 [profile.release]
 debug = true
+
+# [patch.crates-io]
+# minitrace = { path = "../minitrace-rust/minitrace" }
+# minitrace-jaeger = { path = "../minitrace-rust/minitrace-jaeger" }

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ check-all:
 	cargo clippy --all-targets --features tokio-console
 	cargo clippy --all-targets --features trace
 	cargo clippy --all-targets --features sanity
+	cargo clippy --all-targets --features mtrace
 	cargo clippy --all-targets
 
 test:

--- a/foyer-bench/Cargo.toml
+++ b/foyer-bench/Cargo.toml
@@ -21,6 +21,8 @@ hdrhistogram = "7"
 itertools = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = "0.15"
+minitrace = { workspace = true, optional = true }
+minitrace-jaeger = { workspace = true, optional = true }
 opentelemetry = { version = "0.23", optional = true }
 opentelemetry-otlp = { version = "0.16", optional = true }
 opentelemetry-semantic-conventions = { version = "0.15", optional = true }
@@ -54,3 +56,4 @@ trace = [
 strict_assertions = ["foyer/strict_assertions"]
 sanity = ["foyer/sanity"]
 jemalloc = ["tikv-jemallocator"]
+mtrace = ["foyer/mtrace", "minitrace-jaeger", "minitrace"]

--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -19,7 +19,7 @@ mod text;
 use bytesize::MIB;
 use foyer::{
     DirectFsDeviceOptionsBuilder, FifoConfig, FifoPicker, HybridCache, HybridCacheBuilder, InvalidRatioPicker,
-    LfuConfig, LruConfig, RateLimitPicker, RuntimeConfigBuilder, S3FifoConfig,
+    LfuConfig, LruConfig, RateLimitPicker, RuntimeConfigBuilder, S3FifoConfig, TraceConfig,
 };
 use metrics_exporter_prometheus::PrometheusBuilder;
 
@@ -29,7 +29,7 @@ use std::{
     net::SocketAddr,
     ops::{Deref, Range},
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
     time::{Duration, Instant},
@@ -179,6 +179,22 @@ pub struct Args {
 
     #[arg(long, default_value = "lfu")]
     eviction: String,
+
+    /// Record insert trace threshold. Only effective with "mtrace" feature.
+    #[arg(long, default_value_t = 1000 * 1000 * 1000)]
+    trace_insert_ns: usize,
+    /// Record get trace threshold. Only effective with "mtrace" feature.
+    #[arg(long, default_value_t = 1000 * 1000 * 1000)]
+    trace_get_ns: usize,
+    /// Record obtain trace threshold. Only effective with "mtrace" feature.
+    #[arg(long, default_value_t = 1000 * 1000 * 1000)]
+    trace_obtain_ns: usize,
+    /// Record remove trace threshold. Only effective with "mtrace" feature.
+    #[arg(long, default_value_t = 1000 * 1000 * 1000)]
+    trace_remove_ns: usize,
+    /// Record fetch trace threshold. Only effective with "mtrace" feature.
+    #[arg(long, default_value_t = 1000 * 1000 * 1000)]
+    trace_fetch_ns: usize,
 }
 
 #[derive(Debug)]
@@ -316,8 +332,7 @@ fn setup() {
     minitrace::set_reporter(
         reporter,
         Config::default().batch_report_interval(Duration::from_millis(1)),
-    )
-    // minitrace::set_reporter(minitrace::collector::ConsoleReporter, Config::default())
+    );
 }
 
 #[cfg(not(any(feature = "tokio-console", feature = "trace", feature = "mtrace")))]
@@ -388,7 +403,16 @@ async fn main() {
 
     create_dir_all(&args.dir).unwrap();
 
+    let trace_config = TraceConfig {
+        record_hybrid_insert_threshold_ns: AtomicUsize::new(args.trace_insert_ns),
+        record_hybrid_get_threshold_ns: AtomicUsize::new(args.trace_get_ns),
+        record_hybrid_obtain_threshold_ns: AtomicUsize::new(args.trace_obtain_ns),
+        record_hybrid_remove_threshold_ns: AtomicUsize::new(args.trace_remove_ns),
+        record_hybrid_fetch_threshold_ns: AtomicUsize::new(args.trace_fetch_ns),
+    };
+
     let builder = HybridCacheBuilder::new()
+        .with_trace_config(trace_config)
         .memory(args.mem * MIB as usize)
         .with_shards(args.shards);
 

--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -312,9 +312,12 @@ fn setup() {
 #[cfg(feature = "mtrace")]
 fn setup() {
     use minitrace::collector::Config;
-    // let reporter = minitrace_jaeger::JaegerReporter::new("127.0.0.1:6831".parse().unwrap(), "foyer-bench").unwrap();
-    // minitrace::set_reporter(reporter, Config::default())
-    minitrace::set_reporter(minitrace::collector::ConsoleReporter, Config::default())
+    let reporter = minitrace_jaeger::JaegerReporter::new("127.0.0.1:6831".parse().unwrap(), "foyer-bench").unwrap();
+    minitrace::set_reporter(
+        reporter,
+        Config::default().batch_report_interval(Duration::from_millis(1)),
+    )
+    // minitrace::set_reporter(minitrace::collector::ConsoleReporter, Config::default())
 }
 
 #[cfg(not(any(feature = "tokio-console", feature = "trace", feature = "mtrace")))]

--- a/foyer-common/src/lib.rs
+++ b/foyer-common/src/lib.rs
@@ -45,6 +45,8 @@ pub mod rate;
 pub mod rated_ticket;
 /// A runtime that automatically shutdown itself on drop.
 pub mod runtime;
+/// Trace related components.
+pub mod trace;
 
 /// File system utils.
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/foyer-common/src/trace.rs
+++ b/foyer-common/src/trace.rs
@@ -1,0 +1,42 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+
+/// Configurations for trace.
+#[derive(Debug)]
+pub struct TraceConfig {
+    /// Threshold for recording the hybrid cache `insert` and `insert_with_context` operation in ns.
+    pub record_hybrid_insert_threshold_ns: AtomicUsize,
+    /// Threshold for recording the hybrid cache `get` operation in ns.
+    pub record_hybrid_get_threshold_ns: AtomicUsize,
+    /// Threshold for recording the hybrid cache `obtain` operation in ns.
+    pub record_hybrid_obtain_threshold_ns: AtomicUsize,
+    /// Threshold for recording the hybrid cache `remove` operation in ns.
+    pub record_hybrid_remove_threshold_ns: AtomicUsize,
+    /// Threshold for recording the hybrid cache `fetch` operation in ns.
+    pub record_hybrid_fetch_threshold_ns: AtomicUsize,
+}
+
+impl Default for TraceConfig {
+    fn default() -> Self {
+        Self {
+            record_hybrid_insert_threshold_ns: AtomicUsize::from(1000 * 1000 * 1000),
+            record_hybrid_get_threshold_ns: AtomicUsize::from(1000 * 1000 * 1000),
+            record_hybrid_obtain_threshold_ns: AtomicUsize::from(1000 * 1000 * 1000),
+            record_hybrid_remove_threshold_ns: AtomicUsize::from(1000 * 1000 * 1000),
+            record_hybrid_fetch_threshold_ns: AtomicUsize::from(1000 * 1000 * 1000),
+        }
+    }
+}

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -24,6 +24,7 @@ parking_lot = "0.12"
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = "0.1"
+minitrace = { workspace = true }
 
 [dev-dependencies]
 anyhow = "1"
@@ -40,6 +41,7 @@ strict_assertions = [
     "foyer-intrusive/strict_assertions",
 ]
 sanity = ["strict_assertions"]
+mtrace = ["minitrace/enable"]
 
 [[bench]]
 name = "bench_hit_ratio"

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -20,11 +20,11 @@ futures = "0.3"
 hashbrown = "0.14"
 itertools = { workspace = true }
 libc = "0.2"
+minitrace = { workspace = true }
 parking_lot = "0.12"
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = "0.1"
-minitrace = { workspace = true }
 
 [dev-dependencies]
 anyhow = "1"

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -501,6 +501,7 @@ where
     S: HashBuilder,
 {
     /// Insert cache entry to the in-memory cache.
+    #[minitrace::trace(short_name = true)]
     pub fn insert(&self, key: K, value: V) -> CacheEntry<K, V, S> {
         match self {
             Cache::Fifo(cache) => cache.insert(key, value).into(),
@@ -511,6 +512,7 @@ where
     }
 
     /// Insert cache entry with cache context to the in-memory cache.
+    #[minitrace::trace(short_name = true)]
     pub fn insert_with_context(&self, key: K, value: V, context: CacheContext) -> CacheEntry<K, V, S> {
         match self {
             Cache::Fifo(cache) => cache.insert_with_context(key, value, context).into(),
@@ -525,6 +527,7 @@ where
     /// The entry will be removed as soon as the returned entry is dropped.
     ///
     /// The entry will become a normal entry after it is accessed.
+    #[minitrace::trace(short_name = true)]
     pub fn deposit(&self, key: K, value: V) -> CacheEntry<K, V, S> {
         match self {
             Cache::Fifo(cache) => cache.deposit(key, value).into(),
@@ -539,6 +542,7 @@ where
     /// The entry will be removed as soon as the returned entry is dropped.
     ///
     /// The entry will become a normal entry after it is accessed.
+    #[minitrace::trace(short_name = true)]
     pub fn deposit_with_context(&self, key: K, value: V, context: CacheContext) -> CacheEntry<K, V, S> {
         match self {
             Cache::Fifo(cache) => cache.deposit_with_context(key, value, context).into(),
@@ -549,6 +553,7 @@ where
     }
 
     /// Remove a cached entry with the given key from the in-memory cache.
+    #[minitrace::trace(short_name = true)]
     pub fn remove<Q>(&self, key: &Q) -> Option<CacheEntry<K, V, S>>
     where
         K: Borrow<Q>,
@@ -563,6 +568,7 @@ where
     }
 
     /// Get cached entry with the given key from the in-memory cache.
+    #[minitrace::trace(short_name = true)]
     pub fn get<Q>(&self, key: &Q) -> Option<CacheEntry<K, V, S>>
     where
         K: Borrow<Q>,
@@ -577,6 +583,7 @@ where
     }
 
     /// Check if the in-memory cache contains a cached entry with the given key.
+    #[minitrace::trace(short_name = true)]
     pub fn contains<Q>(&self, key: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -593,6 +600,7 @@ where
     /// Access the cached entry with the given key but don't return.
     ///
     /// Note: This method can be used to update the cache eviction information and order based on the algorithm.
+    #[minitrace::trace(short_name = true)]
     pub fn touch<Q>(&self, key: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -607,6 +615,7 @@ where
     }
 
     /// Clear the in-memory cache.
+    #[minitrace::trace(short_name = true)]
     pub fn clear(&self) {
         match self {
             Cache::Fifo(cache) => cache.clear(),
@@ -778,6 +787,7 @@ where
     /// Use `fetch` to fetch the cache value from the remote storage on cache miss.
     ///
     /// The concurrent fetch requests will be deduplicated.
+    #[minitrace::trace(short_name = true)]
     pub fn fetch<F, FU, ER>(&self, key: K, fetch: F) -> Fetch<K, V, ER, S>
     where
         F: FnOnce() -> FU,

--- a/foyer-memory/src/generic.rs
+++ b/foyer-memory/src/generic.rs
@@ -702,6 +702,7 @@ where
     I: Indexer<Key = K, Handle = E::Handle>,
     S: HashBuilder,
 {
+    #[minitrace::trace(short_name = true)]
     pub fn fetch<F, FU, ER>(self: &Arc<Self>, key: K, fetch: F) -> GenericFetch<K, V, E, I, S, ER>
     where
         F: FnOnce() -> FU,

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -29,6 +29,7 @@ itertools = { workspace = true }
 lazy_static = "1"
 libc = "0.2"
 lz4 = "1.24"
+minitrace = { workspace = true }
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 pin-project = "1"
 rand = "0.8"
@@ -51,3 +52,4 @@ strict_assertions = [
     "foyer-common/strict_assertions",
     "foyer-memory/strict_assertions",
 ]
+mtrace = ["minitrace/enable", "foyer-memory/mtrace"]

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -349,6 +349,7 @@ where
         future
     }
 
+    #[minitrace::trace(short_name = true)]
     fn load<Q>(&self, key: &Q) -> impl Future<Output = Result<Option<(K, V)>>> + Send + 'static
     where
         K: Borrow<Q>,

--- a/foyer-storage/src/store/mod.rs
+++ b/foyer-storage/src/store/mod.rs
@@ -175,6 +175,7 @@ where
         }
     }
 
+    #[minitrace::trace(short_name = true)]
     fn load<Q>(&self, key: &Q) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static
     where
         Self::Key: Borrow<Q>,

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -19,6 +19,7 @@ foyer-memory = { version = "0.5.2", path = "../foyer-memory" }
 foyer-storage = { version = "0.8.5", path = "../foyer-storage" }
 tokio = { workspace = true }
 tracing = "0.1"
+minitrace = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -34,3 +35,4 @@ strict_assertions = [
     "foyer-storage/strict_assertions",
 ]
 sanity = ["strict_assertions", "foyer-memory/sanity"]
+mtrace = ["minitrace/enable", "foyer-memory/mtrace", "foyer-storage/mtrace"]

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -17,9 +17,9 @@ anyhow = "1"
 foyer-common = { version = "0.7.3", path = "../foyer-common" }
 foyer-memory = { version = "0.5.2", path = "../foyer-memory" }
 foyer-storage = { version = "0.8.5", path = "../foyer-storage" }
+minitrace = { workspace = true }
 tokio = { workspace = true }
 tracing = "0.1"
-minitrace = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -39,14 +39,8 @@ use super::writer::HybridCacheStorageWriter;
 macro_rules! try_cancel {
     ($self:ident, $span:ident, $threshold:ident) => {
         if let Some(elapsed) = $span.elapsed() {
-            // println!(
-            //     "threshold: {}, op: {}",
-            //     $self.trace_config.$threshold.load(Ordering::Relaxed),
-            //     elapsed.as_nanos() as usize,
-            // );
             if (elapsed.as_nanos() as usize) < $self.trace_config.$threshold.load(Ordering::Relaxed) {
                 $span.cancel();
-                // println!("cancel!");
             }
         }
     };

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -23,6 +23,7 @@ pub use common::{
     code::{Key, StorageKey, StorageValue, Value},
     event::EventListener,
     range::RangeBoundsExt,
+    trace::TraceConfig,
 };
 pub use memory::{CacheContext, EvictionConfig, FetchState, FifoConfig, LfuConfig, LruConfig, S3FifoConfig};
 pub use storage::{


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Implement tail-based tracing with [minitrace](https://github.com/tikv/minitrace-rust). Thank you, @andylokandy. 🙏

Tail-based tracing can be enabled with `mtrace` feature, the recording threshold can be configured by `.with_trace_config(trace_config: TraceConfig)` interface when building the hybrid cache. And the trace config can be dynamically modified with `.trace_config()` interface.

Enable tracing may involve some overhead. It is acceptable to locate the bottleneck for p99+ latency.

With tracing disable, there is no overhead.

Tail-based tracing with jaeger can be enabled with `foyer-bench`, too. Try this:

```bash
# if there was old result
# make monitor && make clear
make monitor
# run foyer-bench and record obtains that are longer than 5ms.
rm -rf /6536/foyer && cargo build --release --features "mtrace" && RUST_BACKTRACE=1 RUST_LOG=info ./target/release/foyer-bench --dir /6536/foyer --mem 64 --disk 102400 --file-size 64 --get-range 10000 --flushers 4 --reclaimers 4 --time 60 --writers 256 --w-rate 4 --admission-rate-limit 500 --readers 1024 --r-rate 1 --runtime --compression none --distribution zipf --distribution-zipf-s 0.8 --metrics --eviction lru --trace-obtain-ns 5000000
```

All related args with foyer-bench:

```plain
      --trace-insert-ns <TRACE_INSERT_NS>
          Record insert trace threshold. Only effective with "mtrace" feature [default: 1000000000]
      --trace-get-ns <TRACE_GET_NS>
          Record get trace threshold. Only effective with "mtrace" feature [default: 1000000000]
      --trace-obtain-ns <TRACE_OBTAIN_NS>
          Record obtain trace threshold. Only effective with "mtrace" feature [default: 1000000000]
      --trace-remove-ns <TRACE_REMOVE_NS>
          Record remove trace threshold. Only effective with "mtrace" feature [default: 1000000000]
      --trace-fetch-ns <TRACE_FETCH_NS>
          Record fetch trace threshold. Only effective with "mtrace" feature [default: 1000000000]
```

Screenshots:

<img width="1914" alt="image" src="https://github.com/MrCroxx/foyer/assets/22407295/fad84d89-e9d1-4413-a0ce-6f08571c7fcb">
<img width="1920" alt="image" src="https://github.com/MrCroxx/foyer/assets/22407295/c4681a8d-7a0d-4905-957f-61def8d378c2">

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
