### PR TITLE
chore: remove binstall on CI

### DIFF
--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -5,7 +5,7 @@ on:
 env:
   RUST_TOOLCHAIN_NIGHTLY: nightly-2024-03-17
   CARGO_TERM_COLOR: always
-  CACHE_KEY_SUFFIX: 20240514
+  CACHE_KEY_SUFFIX: 20240621
 
 jobs:
   misc-check:
@@ -57,14 +57,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-udeps
-      - name: Install cargo-binstall
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       - name: Install cargo-udeps
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          cargo binstall -y cargo-udeps --locked
+          cargo install cargo-udeps --locked
       - name: Unused Dependencies Check
         env:
           RUSTFLAGS: "--cfg tokio_unstable -Awarnings"
@@ -96,14 +92,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-test
-      - name: Install cargo-binstall
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       - name: Install cargo tools
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          cargo binstall -y cargo-sort
+          cargo install cargo-sort --locked
       - name: Run rust cargo-sort check
         run: |
           cargo sort -w -c

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
 env:
   RUST_TOOLCHAIN_NIGHTLY: nightly-2024-03-17
   CARGO_TERM_COLOR: always
-  CACHE_KEY_SUFFIX: 20240514
+  CACHE_KEY_SUFFIX: 20240621
 jobs:
   misc-check:
     name: misc check
@@ -64,14 +64,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-udeps
-      - name: Install cargo-binstall
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       - name: Install cargo-udeps
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          cargo binstall -y cargo-udeps --locked
+          cargo install cargo-udeps --locked
       - name: Unused Dependencies Check
         env:
           RUSTFLAGS: "--cfg tokio_unstable -Awarnings"
@@ -102,14 +98,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-test
-      - name: Install cargo-binstall
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       - name: Install cargo tools
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          cargo binstall -y cargo-sort
+          cargo install cargo-sort --locked
       - name: Run rust cargo-sort check
         run: |
           cargo sort -w -c

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ on:
 env:
   RUST_TOOLCHAIN_NIGHTLY: nightly-2024-03-17
   CARGO_TERM_COLOR: always
-  CACHE_KEY_SUFFIX: 20240514
+  CACHE_KEY_SUFFIX: 20240621
 jobs:
   misc-check:
     name: misc check
@@ -63,14 +63,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-udeps
-      - name: Install cargo-binstall
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       - name: Install cargo-udeps
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          cargo binstall -y cargo-udeps --locked
+          cargo install cargo-udeps --locked
       - name: Unused Dependencies Check
         env:
           RUSTFLAGS: "--cfg tokio_unstable -Awarnings"
@@ -101,14 +97,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-test
-      - name: Install cargo-binstall
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       - name: Install cargo tools
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          cargo binstall -y cargo-sort
+          cargo install cargo-sort --locked
       - name: Run rust cargo-sort check
         run: |
           cargo sort -w -c


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title. For the `binstall` binary always timeout these days.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
