### PR TITLE
feat: introduce tls in-memory cache to reduce lock compete

### DIFF
--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -180,6 +180,10 @@ pub struct Args {
     #[arg(long, default_value = "lfu")]
     eviction: String,
 
+    /// Thread local cache capacity per thread. (MB)
+    #[arg(long, default_value_t = 0)]
+    thread_local_cache_capacity: usize,
+
     /// Record insert trace threshold. Only effective with "mtrace" feature.
     #[arg(long, default_value_t = 1000 * 1000 * 1000)]
     trace_insert_ns: usize,
@@ -423,6 +427,7 @@ async fn main() {
 
     let mut builder = builder
         .with_weighter(|_: &u64, value: &Value| u64::BITS as usize / 8 + value.len())
+        .with_thread_local_cache_capacity(args.thread_local_cache_capacity * MIB as usize)
         .storage()
         .with_device_config(
             DirectFsDeviceOptionsBuilder::new(&args.dir)

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -23,6 +23,7 @@ libc = "0.2"
 minitrace = { workspace = true }
 parking_lot = "0.12"
 serde = { workspace = true }
+thread_local = "1.1"
 tokio = { workspace = true }
 tracing = "0.1"
 

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -299,6 +299,8 @@ where
     weighter: Arc<dyn Weighter<K, V>>,
 
     event_listener: Option<Arc<dyn EventListener<Key = K, Value = V>>>,
+
+    thread_local_cache_capacity: usize,
 }
 
 impl<K, V> CacheBuilder<K, V, RandomState>
@@ -324,6 +326,7 @@ where
             hash_builder: RandomState::default(),
             weighter: Arc::new(|_, _| 1),
             event_listener: None,
+            thread_local_cache_capacity: 0,
         }
     }
 }
@@ -383,6 +386,7 @@ where
             hash_builder,
             weighter: self.weighter,
             event_listener: self.event_listener,
+            thread_local_cache_capacity: self.thread_local_cache_capacity,
         }
     }
 
@@ -398,6 +402,12 @@ where
         self
     }
 
+    /// Set thread local cache capacity.
+    pub fn with_thread_local_cache_capacity(mut self, thread_local_cache_capacity: usize) -> Self {
+        self.thread_local_cache_capacity = thread_local_cache_capacity;
+        self
+    }
+
     /// Build in-memory cache with the given configuration.
     pub fn build(self) -> Cache<K, V, S> {
         match self.eviction_config {
@@ -410,6 +420,7 @@ where
                 hash_builder: self.hash_builder,
                 weighter: self.weighter,
                 event_listener: self.event_listener,
+                thread_local_cache_capacity: self.thread_local_cache_capacity,
             }))),
             EvictionConfig::Lru(eviction_config) => Cache::Lru(Arc::new(GenericCache::new(GenericCacheConfig {
                 name: self.name,
@@ -420,6 +431,7 @@ where
                 hash_builder: self.hash_builder,
                 weighter: self.weighter,
                 event_listener: self.event_listener,
+                thread_local_cache_capacity: self.thread_local_cache_capacity,
             }))),
             EvictionConfig::Lfu(eviction_config) => Cache::Lfu(Arc::new(GenericCache::new(GenericCacheConfig {
                 name: self.name,
@@ -430,6 +442,7 @@ where
                 hash_builder: self.hash_builder,
                 weighter: self.weighter,
                 event_listener: self.event_listener,
+                thread_local_cache_capacity: self.thread_local_cache_capacity,
             }))),
             EvictionConfig::S3Fifo(eviction_config) => Cache::S3Fifo(Arc::new(GenericCache::new(GenericCacheConfig {
                 name: self.name,
@@ -440,6 +453,7 @@ where
                 hash_builder: self.hash_builder,
                 weighter: self.weighter,
                 event_listener: self.event_listener,
+                thread_local_cache_capacity: self.thread_local_cache_capacity,
             }))),
         }
     }

--- a/foyer-memory/src/lib.rs
+++ b/foyer-memory/src/lib.rs
@@ -70,6 +70,7 @@ mod eviction;
 mod generic;
 mod handle;
 mod indexer;
+mod local;
 mod prelude;
 
 pub use prelude::*;

--- a/foyer-memory/src/local.rs
+++ b/foyer-memory/src/local.rs
@@ -1,0 +1,79 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::{borrow::Borrow, collections::VecDeque, hash::Hash};
+
+use foyer_common::code::{HashBuilder, Key, Value};
+use hashbrown::{hash_table::Entry, HashTable};
+
+use crate::{eviction::Eviction, generic::GenericCacheEntry, handle::KeyedHandle, indexer::Indexer};
+
+/// Thread-local cache.
+pub struct LocalCache<K, V, E, I, S>
+where
+    K: Key,
+    V: Value,
+    E: Eviction,
+    E::Handle: KeyedHandle<Key = K, Data = (K, V)>,
+    I: Indexer<Key = K, Handle = E::Handle>,
+    S: HashBuilder,
+{
+    map: HashTable<GenericCacheEntry<K, V, E, I, S>>,
+    queue: VecDeque<GenericCacheEntry<K, V, E, I, S>>,
+
+    capacity: usize,
+    weight: usize,
+}
+
+impl<K, V, E, I, S> LocalCache<K, V, E, I, S>
+where
+    K: Key,
+    V: Value,
+    E: Eviction,
+    E::Handle: KeyedHandle<Key = K, Data = (K, V)>,
+    I: Indexer<Key = K, Handle = E::Handle>,
+    S: HashBuilder,
+{
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            map: HashTable::default(),
+            queue: VecDeque::default(),
+            capacity,
+            weight: 0,
+        }
+    }
+
+    pub fn insert(&mut self, entry: &GenericCacheEntry<K, V, E, I, S>) {
+        match self.map.entry(entry.hash(), |e| e.key() == entry.key(), |e| e.hash()) {
+            Entry::Occupied(_) => return,
+            Entry::Vacant(v) => {
+                v.insert(entry.clone());
+            }
+        }
+        self.weight += entry.weight();
+        self.queue.push_back(entry.clone());
+        while self.weight > self.capacity {
+            let e = self.queue.pop_front().unwrap();
+            self.weight -= e.weight();
+        }
+    }
+
+    pub fn get<Q>(&self, hash: u64, key: &Q) -> Option<GenericCacheEntry<K, V, E, I, S>>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.map.find(hash, |e| e.key().borrow() == key).cloned()
+    }
+}

--- a/foyer/src/hybrid/builder.rs
+++ b/foyer/src/hybrid/builder.rs
@@ -173,6 +173,18 @@ where
         }
     }
 
+    /// Set thread local cache capacity.
+    pub fn with_thread_local_cache_capacity(self, thread_local_cache_capacity: usize) -> Self {
+        let builder = self
+            .builder
+            .with_thread_local_cache_capacity(thread_local_cache_capacity);
+        HybridCacheBuilderPhaseMemory {
+            name: self.name,
+            trace_config: self.trace_config,
+            builder,
+        }
+    }
+
     /// Continue to modify the in-memory cache configurations.
     pub fn storage(self) -> HybridCacheBuilderPhaseStorage<K, V, S> {
         let memory = self.builder.build();


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

```bash
rm -rf /6536/foyer && cargo build --release && RUST_BACKTRACE=1 RUST_LOG=info ./target/release/foyer-bench --dir /6536/foyer --mem 64 --disk 102400 --file-size 64 --get-range 10000 --flushers 4 --reclaimers 4 --time 60 --writers 256 --w-rate 4 --admission-rate-limit 500 --readers 1024 --r-rate 1 --runtime --compression none --distribution zipf --distribution-zipf-s 0.8 --metrics --eviction lru
```

vs 

```bash
... --thread-local-cache-capacity 4
```

<img width="545" alt="image" src="https://github.com/MrCroxx/foyer/assets/22407295/5703df54-fc9b-4ff9-bfb8-00dd68fca954">

There is regression on baseline. I'll fix it later.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#566 