### PR TITLE
fix: fix foyer bench get miss metrics

### DIFF
--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -18,7 +18,7 @@ mod text;
 
 use bytesize::MIB;
 use foyer::{
-    CacheContext, DirectFsDeviceOptionsBuilder, FetchState, FifoConfig, FifoPicker, HybridCache, HybridCacheBuilder,
+    CacheContext, DirectFsDeviceOptionsBuilder, FifoConfig, FifoPicker, HybridCache, HybridCacheBuilder,
     InvalidRatioPicker, LfuConfig, LruConfig, RateLimitPicker, RuntimeConfigBuilder, S3FifoConfig, TraceConfig,
 };
 use metrics_exporter_prometheus::PrometheusBuilder;
@@ -48,7 +48,7 @@ use rand::{
 use rate::RateLimiter;
 use serde::{Deserialize, Serialize};
 use text::text;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, oneshot};
 
 use crate::analyze::IoStat;
 
@@ -699,9 +699,11 @@ async fn read(hybrid: HybridCache<u64, Value>, context: Arc<Context>, mut stop: 
         let idx = w + c * step;
 
         let time = Instant::now();
+        let (miss_tx, mut miss_rx) = oneshot::channel();
         let fetch = hybrid.fetch(idx, || {
             let entry_size = OsRng.gen_range(context.entry_size_range.clone());
             async move {
+                let _ = miss_tx.send(time.elapsed());
                 Ok((
                     Value {
                         inner: Arc::new(text(idx as usize, entry_size)),
@@ -710,10 +712,14 @@ async fn read(hybrid: HybridCache<u64, Value>, context: Arc<Context>, mut stop: 
                 ))
             }
         });
-        let hit = fetch.state() == FetchState::Hit;
-        let miss_lat = time.elapsed().as_micros() as u64;
+
         let entry = fetch.await.unwrap();
         let lat = time.elapsed().as_micros() as u64;
+        let (hit, miss_lat) = if let Ok(elapsed) = miss_rx.try_recv() {
+            (false, elapsed.as_micros() as u64)
+        } else {
+            (true, 0)
+        };
 
         let record = start.elapsed() > context.warm_up;
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

## Baseline

```bash
rm -rf /6536/foyer && cargo build --release && RUST_BACKTRACE=1 RUST_LOG=info ./target/release/foyer-bench --dir /6536/foyer --mem 64 --disk 102400 --file-size 64 --get-range 10000 --flushers 4 --reclaimers 4 --time 60 --writers 256 --w-rate 4 --admission-rate-limit 500 --readers 1024 --r-rate 1 --runtime --compression none --distribution zipf --distribution-zipf-s 0.8 --metrics
```

```
Total:
disk total iops: 3855.8
disk total throughput: 584.1 MiB/s
disk read iops: 1257.0
disk read throughput: 83.5 MiB/s
disk write iops: 2598.8
disk write throughput: 500.6 MiB/s
insert iops: 14253.7/s
insert throughput: 891.0 MiB/s
insert lat p50: 4us
insert lat p90: 7us
insert lat p99: 17us
insert lat p999: 44us
insert lat p9999: 172us
insert lat p99999: 417us
insert lat pmax: 627us
get iops: 17161.7/s
get miss: 7.71% 
get throughput: 1.0 GiB/s
get hit lat p50: 2us
get hit lat p90: 831us
get hit lat p99: 1895us
get hit lat p999: 3311us
get hit lat p9999: 4543us
get hit lat p99999: 5983us
get hit lat pmax: 7007us
get miss lat p50: 33us
get miss lat p90: 162us
get miss lat p99: 455us
get miss lat p999: 967us
get miss lat p9999: 1519us
get miss lat p99999: 1807us
get miss lat pmax: 1807us
```

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#587 