### PR TITLE
feat: write temp buffer before engine enqueue

### DIFF
--- a/foyer-storage/src/engine.rs
+++ b/foyer-storage/src/engine.rs
@@ -28,6 +28,7 @@ use std::{
 use tokio::sync::oneshot;
 
 use crate::{
+    device::IoBuffer,
     error::Result,
     large::generic::{GenericLargeStorage, GenericLargeStorageConfig},
     serde::KvInfo,
@@ -284,7 +285,7 @@ where
     fn enqueue(
         &self,
         entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
-        buffer: Vec<u8>,
+        buffer: IoBuffer,
         info: KvInfo,
         tx: oneshot::Sender<Result<bool>>,
     ) {

--- a/foyer-storage/src/engine.rs
+++ b/foyer-storage/src/engine.rs
@@ -14,6 +14,7 @@
 
 use ahash::RandomState;
 use foyer_common::code::{HashBuilder, StorageKey, StorageValue};
+use foyer_memory::CacheEntry;
 use futures::Future;
 use std::{
     borrow::Borrow,
@@ -24,17 +25,19 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+use tokio::sync::oneshot;
 
 use crate::{
     error::Result,
     large::generic::{GenericLargeStorage, GenericLargeStorageConfig},
+    serde::KvInfo,
     small::generic::{GenericSmallStorage, GenericSmallStorageConfig},
     storage::{
         either::{Either, EitherConfig, Selection, Selector},
         noop::Noop,
         runtime::{Runtime, RuntimeStoreConfig},
     },
-    DeviceStats, EnqueueHandle, Storage,
+    DeviceStats, Storage,
 };
 
 pub struct SizeSelector<K>
@@ -280,17 +283,19 @@ where
 
     fn enqueue(
         &self,
-        entry: foyer_memory::CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
-        force: bool,
-    ) -> EnqueueHandle {
+        entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
+        buffer: Vec<u8>,
+        info: KvInfo,
+        tx: oneshot::Sender<Result<bool>>,
+    ) {
         match self {
-            Engine::Noop(storage) => storage.enqueue(entry, force),
-            Engine::Large(storage) => storage.enqueue(entry, force),
-            Engine::LargeRuntime(storage) => storage.enqueue(entry, force),
-            Engine::Small(storage) => storage.enqueue(entry, force),
-            Engine::SmallRuntime(storage) => storage.enqueue(entry, force),
-            Engine::Combined(storage) => storage.enqueue(entry, force),
-            Engine::CombinedRuntime(storage) => storage.enqueue(entry, force),
+            Engine::Noop(storage) => storage.enqueue(entry, buffer, info, tx),
+            Engine::Large(storage) => storage.enqueue(entry, buffer, info, tx),
+            Engine::LargeRuntime(storage) => storage.enqueue(entry, buffer, info, tx),
+            Engine::Small(storage) => storage.enqueue(entry, buffer, info, tx),
+            Engine::SmallRuntime(storage) => storage.enqueue(entry, buffer, info, tx),
+            Engine::Combined(storage) => storage.enqueue(entry, buffer, info, tx),
+            Engine::CombinedRuntime(storage) => storage.enqueue(entry, buffer, info, tx),
         }
     }
 

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -37,9 +37,9 @@ use crate::{
     device::{monitor::DeviceStats, Dev, DevExt, MonitoredDevice, RegionId},
     error::{Error, Result},
     large::reclaimer::RegionCleaner,
-    picker::{AdmissionPicker, EvictionPicker, ReinsertionPicker},
+    picker::{EvictionPicker, ReinsertionPicker},
     region::RegionManager,
-    serde::EntryDeserializer,
+    serde::{EntryDeserializer, KvInfo},
     statistics::Statistics,
     storage::{EnqueueHandle, Storage},
     tombstone::{Tombstone, TombstoneLog, TombstoneLogConfig},
@@ -80,7 +80,6 @@ where
     pub buffer_threshold: usize,
     pub clean_region_threshold: usize,
     pub eviction_pickers: Vec<Box<dyn EvictionPicker>>,
-    pub admission_picker: Arc<dyn AdmissionPicker<Key = K>>,
     pub reinsertion_picker: Arc<dyn ReinsertionPicker<Key = K>>,
     pub tombstone_log_config: Option<TombstoneLogConfig>,
     pub statistics: Arc<Statistics>,
@@ -107,7 +106,6 @@ where
             .field("buffer_threshold", &self.buffer_threshold)
             .field("clean_region_threshold", &self.clean_region_threshold)
             .field("eviction_pickers", &self.eviction_pickers)
-            .field("admission_pickers", &self.admission_picker)
             .field("reinsertion_pickers", &self.reinsertion_picker)
             .field("tombstone_log_config", &self.tombstone_log_config)
             .field("statistics", &self.statistics)
@@ -150,8 +148,6 @@ where
 
     flushers: Vec<Flusher<K, V, S>>,
     reclaimers: Vec<Reclaimer>,
-
-    admission_picker: Arc<dyn AdmissionPicker<Key = K>>,
 
     statistics: Arc<Statistics>,
 
@@ -272,7 +268,6 @@ where
                 region_manager,
                 flushers,
                 reclaimers,
-                admission_picker: config.admission_picker,
                 statistics: stats,
                 flush: config.flush,
                 sequence,
@@ -294,42 +289,20 @@ where
         self.wait().await
     }
 
-    fn pick(&self, key: &K) -> bool {
-        self.inner.admission_picker.pick(&self.inner.statistics, key)
-    }
-
     #[minitrace::trace(name = "foyer::storage::large::generic::enqueue")]
-    fn enqueue(&self, entry: CacheEntry<K, V, S>, force: bool) -> EnqueueHandle {
-        let now = Instant::now();
+    fn enqueue(&self, entry: CacheEntry<K, V, S>, buffer: Vec<u8>, info: KvInfo, tx: oneshot::Sender<Result<bool>>) {
+        if !self.inner.active.load(Ordering::Relaxed) {
+            tx.send(Err(anyhow::anyhow!("cannot enqueue new entry after closed").into()))
+                .unwrap();
+            return;
+        }
 
-        let (tx, rx) = oneshot::channel();
-        let future = EnqueueHandle::new(rx);
-
-        let this = self.clone();
-
-        self.inner.runtime.spawn(async move {
-            if !this.inner.active.load(Ordering::Relaxed) {
-                tx.send(Err(anyhow::anyhow!("cannot enqueue new entry after closed").into()))
-                    .unwrap();
-                return;
-            }
-
-            if force || this.pick(entry.key()) {
-                let sequence = this.inner.sequence.fetch_add(1, Ordering::Relaxed);
-                this.inner.flushers[sequence as usize % this.inner.flushers.len()].submit(Submission::CacheEntry {
-                    entry,
-                    tx,
-                    sequence,
-                });
-            } else {
-                let _ = tx.send(Ok(false));
-            }
+        let sequence = self.inner.sequence.fetch_add(1, Ordering::Relaxed);
+        self.inner.flushers[sequence as usize % self.inner.flushers.len()].submit(Submission::CacheEntry {
+            entry,
+            tx,
+            sequence,
         });
-
-        self.inner.metrics.storage_enqueue.increment(1);
-        self.inner.metrics.storage_enqueue_duration.record(now.elapsed());
-
-        future
     }
 
     fn load<Q>(&self, key: &Q) -> impl Future<Output = Result<Option<(K, V)>>> + Send + 'static
@@ -494,8 +467,14 @@ where
         self.close().await
     }
 
-    fn enqueue(&self, entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>, force: bool) -> EnqueueHandle {
-        self.enqueue(entry, force)
+    fn enqueue(
+        &self,
+        entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
+        buffer: Vec<u8>,
+        info: KvInfo,
+        tx: oneshot::Sender<Result<bool>>,
+    ) {
+        self.enqueue(entry, buffer, info, tx)
     }
 
     fn load<Q>(&self, key: &Q) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static
@@ -552,7 +531,8 @@ mod tests {
             direct_fs::DirectFsDeviceOptions,
             monitor::{Monitored, MonitoredOptions},
         },
-        picker::utils::{AdmitAllPicker, FifoPicker, RejectAllPicker},
+        picker::utils::{FifoPicker, RejectAllPicker},
+        serde::EntrySerializer,
         test_utils::BiasedPicker,
         tombstone::TombstoneLogConfigBuilder,
     };
@@ -586,35 +566,7 @@ mod tests {
         memory: &Cache<u64, Vec<u8>>,
         dir: impl AsRef<Path>,
     ) -> GenericLargeStorage<u64, Vec<u8>, RandomState> {
-        store_for_test_with_admission_picker(memory, dir, Arc::<AdmitAllPicker<u64>>::default()).await
-    }
-
-    async fn store_for_test_with_admission_picker(
-        memory: &Cache<u64, Vec<u8>>,
-        dir: impl AsRef<Path>,
-        admission_picker: Arc<dyn AdmissionPicker<Key = u64>>,
-    ) -> GenericLargeStorage<u64, Vec<u8>, RandomState> {
-        let device = device_for_test(dir).await;
-        let config = GenericLargeStorageConfig {
-            name: "test".to_string(),
-            memory: memory.clone(),
-            device,
-            compression: Compression::None,
-            flush: true,
-            indexer_shards: 4,
-            recover_mode: RecoverMode::Strict,
-            recover_concurrency: 2,
-            flushers: 1,
-            reclaimers: 1,
-            clean_region_threshold: 1,
-            eviction_pickers: vec![Box::<FifoPicker>::default()],
-            admission_picker,
-            reinsertion_picker: Arc::<RejectAllPicker<u64>>::default(),
-            tombstone_log_config: None,
-            buffer_threshold: usize::MAX,
-            statistics: Arc::<Statistics>::default(),
-        };
-        GenericLargeStorage::open(config).await.unwrap()
+        store_for_test_with_reinsertion_picker(memory, dir, Arc::<RejectAllPicker<u64>>::default()).await
     }
 
     async fn store_for_test_with_reinsertion_picker(
@@ -636,7 +588,6 @@ mod tests {
             reclaimers: 1,
             clean_region_threshold: 1,
             eviction_pickers: vec![Box::<FifoPicker>::default()],
-            admission_picker: Arc::<AdmitAllPicker<u64>>::default(),
             reinsertion_picker,
             tombstone_log_config: None,
             buffer_threshold: usize::MAX,
@@ -664,13 +615,23 @@ mod tests {
             reclaimers: 1,
             clean_region_threshold: 1,
             eviction_pickers: vec![Box::<FifoPicker>::default()],
-            admission_picker: Arc::<AdmitAllPicker<u64>>::default(),
             reinsertion_picker: Arc::<RejectAllPicker<u64>>::default(),
             tombstone_log_config: Some(TombstoneLogConfigBuilder::new(path).with_flush(true).build()),
             buffer_threshold: usize::MAX,
             statistics: Arc::<Statistics>::default(),
         };
         GenericLargeStorage::open(config).await.unwrap()
+    }
+
+    fn enqueue(
+        store: &GenericLargeStorage<u64, Vec<u8>, RandomState>,
+        entry: CacheEntry<u64, Vec<u8>, RandomState>,
+    ) -> EnqueueHandle {
+        let (tx, rx) = oneshot::channel();
+        let mut buffer = Vec::new();
+        let info = EntrySerializer::serialize_kv(entry.key(), entry.value(), &Compression::None, &mut buffer).unwrap();
+        store.enqueue(entry, buffer, info, tx);
+        EnqueueHandle::new(rx)
     }
 
     #[test_log::test(tokio::test)]
@@ -684,8 +645,8 @@ mod tests {
         let e1 = memory.insert(1, vec![1; 7 * KB]);
         let e2 = memory.insert(2, vec![2; 7 * KB]);
 
-        assert!(store.enqueue(e1.clone(), false).await.unwrap());
-        assert!(store.enqueue(e2, false).await.unwrap());
+        assert!(enqueue(&store, e1.clone(),).await.unwrap());
+        assert!(enqueue(&store, e2,).await.unwrap());
 
         let r1 = store.load(&1).await.unwrap().unwrap();
         assert_eq!(r1, (1, vec![1; 7 * KB]));
@@ -696,8 +657,8 @@ mod tests {
         let e3 = memory.insert(3, vec![3; 7 * KB]);
         let e4 = memory.insert(4, vec![4; 6 * KB]);
 
-        assert!(store.enqueue(e3, false).await.unwrap());
-        assert!(store.enqueue(e4, false).await.unwrap());
+        assert!(enqueue(&store, e3,).await.unwrap());
+        assert!(enqueue(&store, e4,).await.unwrap());
 
         let r1 = store.load(&1).await.unwrap().unwrap();
         assert_eq!(r1, (1, vec![1; 7 * KB]));
@@ -710,7 +671,7 @@ mod tests {
 
         // [ [e1, e2], [e3, e4], [e5], [] ]
         let e5 = memory.insert(5, vec![5; 13 * KB]);
-        assert!(store.enqueue(e5, false).await.unwrap());
+        assert!(enqueue(&store, e5,).await.unwrap());
 
         let r1 = store.load(&1).await.unwrap().unwrap();
         assert_eq!(r1, (1, vec![1; 7 * KB]));
@@ -726,8 +687,8 @@ mod tests {
         // [ [], [e3, e4], [e5], [e6, e4*] ]
         let e6 = memory.insert(6, vec![6; 7 * KB]);
         let e4v2 = memory.insert(4, vec![!4; 7 * KB]);
-        assert!(store.enqueue(e6, false).await.unwrap());
-        assert!(store.enqueue(e4v2, false).await.unwrap());
+        assert!(enqueue(&store, e6,).await.unwrap());
+        assert!(enqueue(&store, e4v2,).await.unwrap());
 
         assert!(store.load(&1).await.unwrap().is_none());
         assert!(store.load(&2).await.unwrap().is_none());
@@ -741,7 +702,7 @@ mod tests {
         assert_eq!(r6, (6, vec![6; 7 * KB]));
 
         store.close().await.unwrap();
-        assert!(store.enqueue(e1, false).await.is_err());
+        assert!(enqueue(&store, e1,).await.is_err());
         drop(store);
 
         let store = store_for_test(&memory, dir.path()).await;
@@ -767,7 +728,7 @@ mod tests {
 
         let es = (0..10).map(|i| memory.insert(i, vec![i as u8; 7 * KB])).collect_vec();
 
-        assert!(try_join_all(es.iter().take(6).map(|e| store.enqueue(e.clone(), false)))
+        assert!(try_join_all(es.iter().take(6).map(|e| enqueue(&store, e.clone(),)))
             .await
             .unwrap()
             .into_iter()
@@ -792,7 +753,7 @@ mod tests {
             }
         }
 
-        assert!(store.enqueue(es[3].clone(), false).await.unwrap());
+        assert!(enqueue(&store, es[3].clone(),).await.unwrap());
         assert_eq!(store.load(&3).await.unwrap(), Some((3, vec![3; 7 * KB])));
 
         store.close().await.unwrap();
@@ -812,7 +773,7 @@ mod tests {
 
         let es = (0..10).map(|i| memory.insert(i, vec![i as u8; 7 * KB])).collect_vec();
 
-        assert!(try_join_all(es.iter().take(6).map(|e| store.enqueue(e.clone(), false)))
+        assert!(try_join_all(es.iter().take(6).map(|e| enqueue(&store, e.clone(),)))
             .await
             .unwrap()
             .into_iter()
@@ -835,7 +796,7 @@ mod tests {
             assert_eq!(store.load(&i).await.unwrap(), None);
         }
 
-        assert!(store.enqueue(es[3].clone(), false).await.unwrap());
+        assert!(enqueue(&store, es[3].clone(),).await.unwrap());
         assert_eq!(store.load(&3).await.unwrap(), Some((3, vec![3; 7 * KB])));
 
         store.close().await.unwrap();
@@ -846,23 +807,24 @@ mod tests {
         assert_eq!(store.load(&3).await.unwrap(), Some((3, vec![3; 7 * KB])));
     }
 
-    #[test_log::test(tokio::test)]
-    async fn test_store_admission() {
-        let dir = tempfile::tempdir().unwrap();
+    // FIXME(MrCroxx): Move the admission test to store level.
+    // #[test_log::test(tokio::test)]
+    // async fn test_store_admission() {
+    //     let dir = tempfile::tempdir().unwrap();
 
-        let memory = cache_for_test();
-        let store = store_for_test_with_admission_picker(&memory, dir.path(), Arc::new(BiasedPicker::new([1]))).await;
+    //     let memory = cache_for_test();
+    //     let store = store_for_test_with_admission_picker(&memory, dir.path(), Arc::new(BiasedPicker::new([1]))).await;
 
-        let e1 = memory.insert(1, vec![1; 7 * KB]);
-        let e2 = memory.insert(2, vec![2; 7 * KB]);
+    //     let e1 = memory.insert(1, vec![1; 7 * KB]);
+    //     let e2 = memory.insert(2, vec![2; 7 * KB]);
 
-        assert!(store.enqueue(e1.clone(), false).await.unwrap());
-        assert!(!store.enqueue(e2, false).await.unwrap());
+    //     assert!(enqueue(&store, e1.clone(),).await.unwrap());
+    //     assert!(!enqueue(&store, e2,).await.unwrap());
 
-        let r1 = store.load(&1).await.unwrap().unwrap();
-        assert_eq!(r1, (1, vec![1; 7 * KB]));
-        assert!(store.load(&2).await.unwrap().is_none());
-    }
+    //     let r1 = store.load(&1).await.unwrap().unwrap();
+    //     assert_eq!(r1, (1, vec![1; 7 * KB]));
+    //     assert!(store.load(&2).await.unwrap().is_none());
+    // }
 
     #[test_log::test(tokio::test)]
     async fn test_store_reinsertion() {
@@ -880,7 +842,7 @@ mod tests {
 
         // [ [e0, e1], [e2, e3], [e4, e5], [] ]
         for e in es.iter().take(6).cloned() {
-            assert!(store.enqueue(e, false).await.unwrap());
+            assert!(enqueue(&store, e,).await.unwrap());
         }
         for i in 0..6 {
             let r = store.load(&i).await.unwrap().unwrap();
@@ -888,7 +850,7 @@ mod tests {
         }
 
         // [ [], [e2, e3], [e4, e5], [e6, e1] ]
-        assert!(store.enqueue(es[6].clone(), false).await.unwrap());
+        assert!(enqueue(&store, es[6].clone(),).await.unwrap());
         for reclaimer in store.inner.reclaimers.iter() {
             reclaimer.wait().await;
         }
@@ -910,7 +872,7 @@ mod tests {
         );
 
         // [ [e7, e3], [], [e4, e5], [e6, e1] ]
-        assert!(store.enqueue(es[7].clone(), false).await.unwrap());
+        assert!(enqueue(&store, es[7].clone(),).await.unwrap());
         for reclaimer in store.inner.reclaimers.iter() {
             reclaimer.wait().await;
         }
@@ -934,8 +896,8 @@ mod tests {
 
         // [ [e7, e3], [e8, e9], [], [e6, e1] ]
         store.delete(&5).await.unwrap();
-        assert!(store.enqueue(es[8].clone(), false).await.unwrap());
-        assert!(store.enqueue(es[9].clone(), false).await.unwrap());
+        assert!(enqueue(&store, es[8].clone(),).await.unwrap());
+        assert!(enqueue(&store, es[9].clone(),).await.unwrap());
         for reclaimer in store.inner.reclaimers.iter() {
             reclaimer.wait().await;
         }

--- a/foyer-storage/src/serde.rs
+++ b/foyer-storage/src/serde.rs
@@ -26,10 +26,15 @@ use crate::{
     Sequence,
 };
 
-pub fn checksum(buf: &[u8]) -> u64 {
-    let mut hasher = XxHash64::with_seed(0);
-    hasher.write(buf);
-    hasher.finish()
+#[derive(Debug)]
+pub struct Checksummer;
+
+impl Checksummer {
+    pub fn checksum(buf: &[u8]) -> u64 {
+        let mut hasher = XxHash64::with_seed(0);
+        hasher.write(buf);
+        hasher.finish()
+    }
 }
 
 const ENTRY_MAGIC: u32 = 0x97_03_27_00;
@@ -54,7 +59,7 @@ impl EntryHeader {
         Self::serialized_len() + self.key_len as usize + self.value_len as usize
     }
 
-    pub fn write(&self, mut buf: &mut [u8]) {
+    pub fn write(&self, mut buf: impl BufMut) {
         buf.put_u32(self.key_len);
         buf.put_u32(self.value_len);
         buf.put_u64(self.hash);
@@ -65,7 +70,7 @@ impl EntryHeader {
         buf.put_u32(v);
     }
 
-    pub fn read(mut buf: &[u8]) -> Result<Self> {
+    pub fn read(mut buf: impl Buf) -> Result<Self> {
         let key_len = buf.get_u32();
         let value_len = buf.get_u32();
         let hash = buf.get_u64();
@@ -98,6 +103,7 @@ impl EntryHeader {
     }
 }
 
+#[derive(Debug)]
 pub struct KvInfo {
     pub key_len: usize,
     pub value_len: usize,
@@ -110,79 +116,13 @@ impl EntrySerializer {
     pub fn serialize<'a, K, V, A>(
         key: &'a K,
         value: &'a V,
-        hash: u64,
-        sequence: &'a Sequence,
         compression: &'a Compression,
         mut buffer: WritableVecA<'a, u8, A>,
-    ) -> Result<()>
-    where
-        K: StorageKey,
-        V: StorageValue,
-        A: Allocator,
-    {
-        let mut cursor = buffer.len();
-
-        // reserve space for header, header will be filled after the serialized len is known
-        cursor += EntryHeader::serialized_len();
-        buffer.reserve(EntryHeader::serialized_len());
-        unsafe { buffer.set_len(cursor) };
-
-        // serialize value
-        match compression {
-            Compression::None => {
-                bincode::serialize_into(&mut buffer, &value).map_err(Error::from)?;
-            }
-            Compression::Zstd => {
-                let encoder = zstd::Encoder::new(&mut buffer, 0).map_err(Error::from)?.auto_finish();
-                bincode::serialize_into(encoder, &value).map_err(Error::from)?;
-            }
-
-            Compression::Lz4 => {
-                let encoder = lz4::EncoderBuilder::new()
-                    .checksum(lz4::ContentChecksum::NoChecksum)
-                    .auto_flush(true)
-                    .build(&mut buffer)
-                    .map_err(Error::from)?;
-                bincode::serialize_into(encoder, &value).map_err(Error::from)?;
-            }
-        }
-
-        let value_len = buffer.len() - cursor;
-        cursor = buffer.len();
-
-        // serialize key
-        bincode::serialize_into(WritableVecA(&mut buffer), &key).map_err(Error::from)?;
-        let key_len = buffer.len() - cursor;
-        cursor = buffer.len();
-
-        // calculate checksum
-        cursor -= value_len + key_len;
-        let checksum = checksum(&buffer[cursor..cursor + value_len + key_len]);
-
-        // serialize entry header
-        cursor -= EntryHeader::serialized_len();
-        let header = EntryHeader {
-            key_len: key_len as u32,
-            value_len: value_len as u32,
-            hash,
-            sequence: *sequence,
-            compression: *compression,
-            checksum,
-        };
-        header.write(&mut buffer[cursor..cursor + EntryHeader::serialized_len()]);
-
-        Ok(())
-    }
-
-    pub fn serialize_kv<'a, K, V>(
-        key: &'a K,
-        value: &'a V,
-        compression: &'a Compression,
-        mut buffer: &'a mut Vec<u8>,
     ) -> Result<KvInfo>
     where
         K: StorageKey,
         V: StorageValue,
+        A: Allocator,
     {
         let mut cursor = buffer.len();
 
@@ -240,7 +180,7 @@ impl EntryDeserializer {
         let key = Self::deserialize_key(buf)?;
         offset += header.key_len as usize;
 
-        let checksum = checksum(&buffer[EntryHeader::serialized_len()..offset]);
+        let checksum = Checksummer::checksum(&buffer[EntryHeader::serialized_len()..offset]);
         if checksum != header.checksum {
             return Err(Error::ChecksumMismatch {
                 expected: header.checksum,

--- a/foyer-storage/src/small/generic.rs
+++ b/foyer-storage/src/small/generic.rs
@@ -22,7 +22,13 @@ use tokio::sync::oneshot;
 
 use std::{borrow::Borrow, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
 
-use crate::{device::Dev, error::Result, serde::KvInfo, storage::Storage, DeviceStats, EnqueueHandle};
+use crate::{
+    device::{Dev, IoBuffer},
+    error::Result,
+    serde::KvInfo,
+    storage::Storage,
+    DeviceStats, EnqueueHandle,
+};
 
 pub struct GenericSmallStorageConfig<K, V, S>
 where
@@ -97,7 +103,7 @@ where
     fn enqueue(
         &self,
         entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
-        buffer: Vec<u8>,
+        buffer: IoBuffer,
         info: KvInfo,
         tx: oneshot::Sender<Result<bool>>,
     ) {

--- a/foyer-storage/src/small/generic.rs
+++ b/foyer-storage/src/small/generic.rs
@@ -18,10 +18,11 @@
 use foyer_common::code::{HashBuilder, StorageKey, StorageValue};
 use foyer_memory::CacheEntry;
 use futures::Future;
+use tokio::sync::oneshot;
 
 use std::{borrow::Borrow, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
 
-use crate::{device::Dev, error::Result, storage::Storage, DeviceStats, EnqueueHandle};
+use crate::{device::Dev, error::Result, serde::KvInfo, storage::Storage, DeviceStats, EnqueueHandle};
 
 pub struct GenericSmallStorageConfig<K, V, S>
 where
@@ -96,8 +97,10 @@ where
     fn enqueue(
         &self,
         entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
-        force: bool,
-    ) -> crate::EnqueueHandle {
+        buffer: Vec<u8>,
+        info: KvInfo,
+        tx: oneshot::Sender<Result<bool>>,
+    ) {
         todo!()
     }
 

--- a/foyer-storage/src/storage/either.rs
+++ b/foyer-storage/src/storage/either.rs
@@ -20,7 +20,7 @@ use futures::{
 };
 use tokio::{runtime::Handle, sync::oneshot};
 
-use crate::{error::Result, serde::KvInfo, storage::Storage, DeviceStats, EnqueueHandle};
+use crate::{device::IoBuffer, error::Result, serde::KvInfo, storage::Storage, DeviceStats, EnqueueHandle};
 
 use std::{borrow::Borrow, fmt::Debug, hash::Hash, sync::Arc};
 
@@ -152,7 +152,7 @@ where
     fn enqueue(
         &self,
         entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
-        buffer: Vec<u8>,
+        buffer: IoBuffer,
         info: KvInfo,
         tx: oneshot::Sender<Result<bool>>,
     ) {

--- a/foyer-storage/src/storage/mod.rs
+++ b/foyer-storage/src/storage/mod.rs
@@ -31,7 +31,7 @@ use foyer_memory::CacheEntry;
 use pin_project::pin_project;
 use tokio::{runtime::Handle, sync::oneshot};
 
-use crate::{device::monitor::DeviceStats, error::Result};
+use crate::{device::monitor::DeviceStats, error::Result, serde::KvInfo};
 
 /// The handle created by [`Storage::enqueue`].
 #[pin_project]
@@ -79,7 +79,13 @@ pub trait Storage: Send + Sync + 'static + Clone + Debug {
     fn close(&self) -> impl Future<Output = Result<()>> + Send;
 
     /// Push a in-memory cache entry to the disk cache write queue.
-    fn enqueue(&self, entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>, force: bool) -> EnqueueHandle;
+    fn enqueue(
+        &self,
+        entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
+        buffer: Vec<u8>,
+        info: KvInfo,
+        tx: oneshot::Sender<Result<bool>>,
+    );
 
     /// Load a cache entry from the disk cache.
     ///

--- a/foyer-storage/src/storage/mod.rs
+++ b/foyer-storage/src/storage/mod.rs
@@ -31,7 +31,11 @@ use foyer_memory::CacheEntry;
 use pin_project::pin_project;
 use tokio::{runtime::Handle, sync::oneshot};
 
-use crate::{device::monitor::DeviceStats, error::Result, serde::KvInfo};
+use crate::{
+    device::{monitor::DeviceStats, IoBuffer},
+    error::Result,
+    serde::KvInfo,
+};
 
 /// The handle created by [`Storage::enqueue`].
 #[pin_project]
@@ -82,7 +86,7 @@ pub trait Storage: Send + Sync + 'static + Clone + Debug {
     fn enqueue(
         &self,
         entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
-        buffer: Vec<u8>,
+        buffer: IoBuffer,
         info: KvInfo,
         tx: oneshot::Sender<Result<bool>>,
     );

--- a/foyer-storage/src/storage/noop.rs
+++ b/foyer-storage/src/storage/noop.rs
@@ -22,6 +22,7 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 
 use crate::device::monitor::DeviceStats;
+use crate::device::IoBuffer;
 use crate::serde::KvInfo;
 use crate::storage::{EnqueueHandle, Storage};
 
@@ -87,7 +88,7 @@ where
     fn enqueue(
         &self,
         _entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
-        _buffer: Vec<u8>,
+        _buffer: IoBuffer,
         _info: KvInfo,
         tx: oneshot::Sender<Result<bool>>,
     ) {
@@ -144,6 +145,8 @@ where
 mod tests {
     use foyer_memory::{Cache, CacheBuilder, FifoConfig};
 
+    use crate::device::IO_BUFFER_ALLOCATOR;
+
     use super::*;
 
     fn cache_for_test() -> Cache<u64, Vec<u8>> {
@@ -159,7 +162,7 @@ mod tests {
         let (tx, rx) = oneshot::channel();
         store.enqueue(
             memory.insert(0, vec![b'x'; 16384]),
-            vec![],
+            IoBuffer::new_in(&IO_BUFFER_ALLOCATOR),
             KvInfo {
                 key_len: 0,
                 value_len: 0,

--- a/foyer-storage/src/storage/noop.rs
+++ b/foyer-storage/src/storage/noop.rs
@@ -22,6 +22,7 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 
 use crate::device::monitor::DeviceStats;
+use crate::serde::KvInfo;
 use crate::storage::{EnqueueHandle, Storage};
 
 use crate::error::Result;
@@ -83,10 +84,14 @@ where
         Ok(())
     }
 
-    fn enqueue(&self, _: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>, force: bool) -> EnqueueHandle {
-        let (tx, rx) = oneshot::channel();
-        let _ = tx.send(Ok(force)); // always return `force` here to keep consistency
-        EnqueueHandle::new(rx)
+    fn enqueue(
+        &self,
+        _entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
+        _buffer: Vec<u8>,
+        _info: KvInfo,
+        tx: oneshot::Sender<Result<bool>>,
+    ) {
+        let _ = tx.send(Ok(false));
     }
 
     // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
@@ -151,7 +156,17 @@ mod tests {
     async fn test_none_store() {
         let memory = cache_for_test();
         let store = Noop::open(()).await.unwrap();
-        assert!(!store.enqueue(memory.insert(0, vec![b'x'; 16384]), false).await.unwrap());
+        let (tx, rx) = oneshot::channel();
+        store.enqueue(
+            memory.insert(0, vec![b'x'; 16384]),
+            vec![],
+            KvInfo {
+                key_len: 0,
+                value_len: 0,
+            },
+            tx,
+        );
+        assert!(!rx.await.unwrap().unwrap());
         assert!(store.load(&0).await.unwrap().is_none());
         store.delete(&0).await.unwrap();
         store.destroy().await.unwrap();

--- a/foyer-storage/src/storage/runtime.rs
+++ b/foyer-storage/src/storage/runtime.rs
@@ -18,10 +18,12 @@ use foyer_common::runtime::BackgroundShutdownRuntime;
 use foyer_memory::CacheEntry;
 use futures::{Future, FutureExt};
 use tokio::runtime::Handle;
+use tokio::sync::oneshot;
 
 use crate::device::monitor::DeviceStats;
 use crate::error::Result;
 
+use crate::serde::KvInfo;
 use crate::storage::{EnqueueHandle, Storage};
 
 /// The builder of the disk cache with a dedicated runtime.
@@ -148,8 +150,14 @@ where
         self.runtime.spawn(async move { store.close().await }).await.unwrap()
     }
 
-    fn enqueue(&self, entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>, force: bool) -> EnqueueHandle {
-        self.store.enqueue(entry, force)
+    fn enqueue(
+        &self,
+        entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
+        buffer: Vec<u8>,
+        info: KvInfo,
+        tx: oneshot::Sender<Result<bool>>,
+    ) {
+        self.store.enqueue(entry, buffer, info, tx)
     }
 
     fn load<Q>(&self, key: &Q) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static
@@ -215,7 +223,8 @@ mod tests {
             generic::{GenericLargeStorage, GenericLargeStorageConfig},
             recover::RecoverMode,
         },
-        picker::utils::{AdmitAllPicker, FifoPicker, RejectAllPicker},
+        picker::utils::{FifoPicker, RejectAllPicker},
+        serde::EntrySerializer,
         storage::Storage,
         Statistics,
     };
@@ -262,7 +271,6 @@ mod tests {
             reclaimers: 1,
             clean_region_threshold: 1,
             eviction_pickers: vec![Box::<FifoPicker>::default()],
-            admission_picker: Arc::<AdmitAllPicker<u64>>::default(),
             reinsertion_picker: Arc::<RejectAllPicker<u64>>::default(),
             tombstone_log_config: None,
             buffer_threshold: usize::MAX,
@@ -289,7 +297,17 @@ mod tests {
             GenericLargeStorage::open(config).await.unwrap()
         });
 
-        let fs = es.iter().cloned().map(|e| store.enqueue(e, false)).collect_vec();
+        let fs = es
+            .iter()
+            .cloned()
+            .map(|e| {
+                let (tx, rx) = oneshot::channel();
+                let mut buffer = Vec::new();
+                let info = EntrySerializer::serialize_kv(e.key(), e.value(), &Compression::None, &mut buffer).unwrap();
+                store.enqueue(e, buffer, info, tx);
+                rx.map(|res| res.unwrap())
+            })
+            .collect_vec();
         background.block_on(async { try_join_all(fs).await.unwrap() });
 
         let mut fs = vec![];

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -26,6 +26,7 @@ use crate::{
         utils::{AdmitAllPicker, FifoPicker, InvalidRatioPicker, RejectAllPicker},
         AdmissionPicker, EvictionPicker, ReinsertionPicker,
     },
+    serde::EntrySerializer,
     small::generic::GenericSmallStorageConfig,
     statistics::Statistics,
     storage::{
@@ -43,8 +44,8 @@ use foyer_common::{
 };
 use foyer_memory::{Cache, CacheEntry};
 use futures::Future;
-use std::{borrow::Borrow, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
-use tokio::runtime::Handle;
+use std::{borrow::Borrow, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc, time::Instant};
+use tokio::{runtime::Handle, sync::oneshot};
 
 /// The disk cache engine that serves as the storage backend of `foyer`.
 pub struct Store<K, V, S = RandomState>
@@ -55,7 +56,9 @@ where
 {
     engine: Engine<K, V, S>,
     admission_picker: Arc<dyn AdmissionPicker<Key = K>>,
+    compression: Compression,
     statistics: Arc<Statistics>,
+    metrics: Arc<Metrics>,
 }
 
 impl<K, V, S> Debug for Store<K, V, S>
@@ -68,6 +71,7 @@ where
         f.debug_struct("Store")
             .field("engine", &self.engine)
             .field("admission_picker", &self.admission_picker)
+            .field("compression", &self.compression)
             .field("statistics", &self.statistics)
             .finish()
     }
@@ -83,7 +87,9 @@ where
         Self {
             engine: self.engine.clone(),
             admission_picker: self.admission_picker.clone(),
+            compression: self.compression,
             statistics: self.statistics.clone(),
+            metrics: self.metrics.clone(),
         }
     }
 }
@@ -108,7 +114,34 @@ where
 
     /// Push a in-memory cache entry to the disk cache write queue.
     pub fn enqueue(&self, entry: CacheEntry<K, V, S>, force: bool) -> EnqueueHandle {
-        self.engine.enqueue(entry, force)
+        let now = Instant::now();
+
+        let (tx, rx) = oneshot::channel();
+        let future = EnqueueHandle::new(rx);
+        let compression = self.compression;
+        let this = self.clone();
+
+        self.runtime().spawn(async move {
+            if force || this.pick(entry.key()) {
+                let mut buffer = Vec::new();
+                match EntrySerializer::serialize_kv(entry.key(), entry.value(), &compression, &mut buffer) {
+                    Ok(info) => {
+                        this.engine.enqueue(entry, buffer, info, tx);
+                    }
+                    Err(e) => {
+                        tracing::warn!("[store]: serialize kv error: {e}");
+                        let _ = tx.send(Ok(false));
+                    }
+                }
+            } else {
+                let _ = tx.send(Ok(false));
+            }
+        });
+
+        self.metrics.storage_enqueue.increment(1);
+        self.metrics.storage_enqueue_duration.record(now.elapsed());
+
+        future
     }
 
     /// Load a cache entry from the disk cache.
@@ -463,7 +496,11 @@ where
                 Engine::open(EngineConfig::Noop).await?
             }
             DeviceConfig::DeviceOptions(options) => {
-                let device = Monitored::open(MonitoredOptions { options, metrics }).await?;
+                let device = Monitored::open(MonitoredOptions {
+                    options,
+                    metrics: metrics.clone(),
+                })
+                .await?;
                 match (self.combined_config, self.runtime_config) {
                     (CombinedConfig::Large, None) => {
                         Engine::open(EngineConfig::Large(GenericLargeStorageConfig {
@@ -479,7 +516,6 @@ where
                             reclaimers: self.reclaimers,
                             clean_region_threshold,
                             eviction_pickers: self.eviction_pickers,
-                            admission_picker: self.admission_picker,
                             reinsertion_picker: self.reinsertion_picker,
                             tombstone_log_config: self.tombstone_log_config,
                             buffer_threshold: self.buffer_threshold,
@@ -502,7 +538,6 @@ where
                                 reclaimers: self.reclaimers,
                                 clean_region_threshold,
                                 eviction_pickers: self.eviction_pickers,
-                                admission_picker: self.admission_picker,
                                 reinsertion_picker: self.reinsertion_picker,
                                 tombstone_log_config: self.tombstone_log_config,
                                 buffer_threshold: self.buffer_threshold,
@@ -551,7 +586,6 @@ where
                                 reclaimers: self.reclaimers,
                                 clean_region_threshold,
                                 eviction_pickers: self.eviction_pickers,
-                                admission_picker: self.admission_picker,
                                 reinsertion_picker: self.reinsertion_picker,
                                 tombstone_log_config: self.tombstone_log_config,
                                 buffer_threshold: self.buffer_threshold,
@@ -585,7 +619,6 @@ where
                                     reclaimers: self.reclaimers,
                                     clean_region_threshold,
                                     eviction_pickers: self.eviction_pickers,
-                                    admission_picker: self.admission_picker,
                                     reinsertion_picker: self.reinsertion_picker,
                                     tombstone_log_config: self.tombstone_log_config,
                                     buffer_threshold: self.buffer_threshold,
@@ -603,7 +636,9 @@ where
         Ok(Store {
             engine,
             admission_picker,
+            compression: self.compression,
             statistics,
+            metrics,
         })
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Serialize cache entry to a temporary buffer before enqueue to engine.

This method makes the serialized entry size known before submitting it to the engine, making it possible to decide which engine to use with the serialized entry size.

But this PR may increase some memory usage when the buffer is waiting to be written to the main buffer. Maybe use parallel buffer writing.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#596 