### PR TITLE
feat: refine either storage

### DIFF
--- a/foyer-common/src/future.rs
+++ b/foyer-common/src/future.rs
@@ -42,6 +42,7 @@ impl<T, S> From<T> for Diversion<T, S> {
 }
 
 /// [`DiversionFuture`] is a future wrapper that partially store and partially return the future result.
+#[must_use]
 #[pin_project]
 pub struct DiversionFuture<FU, T, S> {
     #[pin]

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -29,7 +29,7 @@ pub use crate::{
     statistics::Statistics,
     storage::{
         runtime::{RuntimeConfig, RuntimeConfigBuilder},
-        EnqueueHandle, Storage,
+        Storage, WaitHandle,
     },
     store::{CombinedConfig, DeviceConfig, Store, StoreBuilder},
     tombstone::{TombstoneLogConfig, TombstoneLogConfigBuilder},

--- a/foyer-storage/src/small/generic.rs
+++ b/foyer-storage/src/small/generic.rs
@@ -12,9 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.use std::marker::PhantomData;
 
-// FIXME: REMOVE ME!!!
-#![allow(unused)]
-
 use foyer_common::code::{HashBuilder, StorageKey, StorageValue};
 use foyer_memory::CacheEntry;
 use futures::Future;
@@ -23,11 +20,11 @@ use tokio::sync::oneshot;
 use std::{borrow::Borrow, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
 
 use crate::{
-    device::{Dev, IoBuffer},
+    device::IoBuffer,
     error::Result,
     serde::KvInfo,
-    storage::Storage,
-    DeviceStats, EnqueueHandle,
+    storage::{Storage, WaitHandle},
+    DeviceStats,
 };
 
 pub struct GenericSmallStorageConfig<K, V, S>
@@ -92,7 +89,7 @@ where
     type BuildHasher = S;
     type Config = GenericSmallStorageConfig<K, V, S>;
 
-    async fn open(config: Self::Config) -> Result<Self> {
+    async fn open(_config: Self::Config) -> Result<Self> {
         todo!()
     }
 
@@ -102,10 +99,10 @@ where
 
     fn enqueue(
         &self,
-        entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
-        buffer: IoBuffer,
-        info: KvInfo,
-        tx: oneshot::Sender<Result<bool>>,
+        _entry: CacheEntry<Self::Key, Self::Value, Self::BuildHasher>,
+        _buffer: IoBuffer,
+        _info: KvInfo,
+        _tx: oneshot::Sender<Result<bool>>,
     ) {
         todo!()
     }
@@ -113,7 +110,7 @@ where
     // FIXME: REMOVE THE CLIPPY IGNORE.
     // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
     #[allow(clippy::manual_async_fn)]
-    fn load<Q>(&self, key: &Q) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static
+    fn load<Q>(&self, _key: &Q) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static
     where
         Self::Key: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized + Send + Sync + 'static,
@@ -121,15 +118,15 @@ where
         async { todo!() }
     }
 
-    fn delete<Q>(&self, key: &Q) -> EnqueueHandle
+    fn delete<Q>(&self, _key: &Q) -> WaitHandle<impl Future<Output = Result<bool>> + Send + 'static>
     where
         Self::Key: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        todo!()
+        WaitHandle::new(async move { todo!() })
     }
 
-    fn may_contains<Q>(&self, key: &Q) -> bool
+    fn may_contains<Q>(&self, _key: &Q) -> bool
     where
         Self::Key: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,

--- a/foyer-storage/src/storage/either.rs
+++ b/foyer-storage/src/storage/either.rs
@@ -15,14 +15,16 @@
 use foyer_common::code::{HashBuilder, StorageKey, StorageValue};
 use foyer_memory::CacheEntry;
 use futures::{
-    future::{try_join, Either as EitherFuture},
-    Future,
+    future::{ready, select, try_join, Either as EitherFuture},
+    pin_mut, Future, FutureExt,
 };
 use tokio::{runtime::Handle, sync::oneshot};
 
-use crate::{device::IoBuffer, error::Result, serde::KvInfo, storage::Storage, DeviceStats, EnqueueHandle};
+use crate::{device::IoBuffer, error::Result, serde::KvInfo, storage::Storage, DeviceStats};
 
 use std::{borrow::Borrow, fmt::Debug, hash::Hash, sync::Arc};
+
+use super::WaitHandle;
 
 pub struct EitherConfig<K, V, S, SL, SR, SE>
 where
@@ -63,12 +65,11 @@ pub enum Selection {
 }
 
 pub trait Selector: Send + Sync + 'static + Debug {
-    type Key;
+    type Key: StorageKey;
+    type Value: StorageValue;
+    type BuildHasher: HashBuilder;
 
-    fn select<Q>(&self, key: &Q) -> Selection
-    where
-        Self::Key: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+    fn select(&self, entry: &CacheEntry<Self::Key, Self::Value, Self::BuildHasher>, buffer: &IoBuffer) -> Selection;
 }
 
 pub struct Either<K, V, S, SL, SR, SE>
@@ -128,7 +129,7 @@ where
     S: HashBuilder + Debug,
     SL: Storage<Key = K, Value = V, BuildHasher = S>,
     SR: Storage<Key = K, Value = V, BuildHasher = S>,
-    SE: Selector<Key = K>,
+    SE: Selector<Key = K, Value = V, BuildHasher = S>,
 {
     type Key = K;
     type Value = V;
@@ -156,9 +157,15 @@ where
         info: KvInfo,
         tx: oneshot::Sender<Result<bool>>,
     ) {
-        match self.selector.select(entry.key()) {
-            Selection::Left => self.left.enqueue(entry, buffer, info, tx),
-            Selection::Right => self.right.enqueue(entry, buffer, info, tx),
+        match self.selector.select(&entry, &buffer) {
+            Selection::Left => {
+                self.right.delete(entry.key());
+                self.left.enqueue(entry, buffer, info, tx);
+            }
+            Selection::Right => {
+                self.right.delete(entry.key());
+                self.right.enqueue(entry, buffer, info, tx);
+            }
         }
     }
 
@@ -167,21 +174,39 @@ where
         Self::Key: Borrow<Q>,
         Q: Hash + Eq + ?Sized + Send + Sync + 'static,
     {
-        match self.selector.select(key) {
-            Selection::Left => EitherFuture::Left(self.left.load(key)),
-            Selection::Right => EitherFuture::Right(self.right.load(key)),
+        let fleft = self.left.load(key);
+        let fright = self.right.load(key);
+
+        async move {
+            pin_mut!(fleft);
+            pin_mut!(fright);
+
+            // Returns a 4-way `Either` by nesting `Either` in `Either`.
+            select(fleft, fright)
+                .then(|either| match either {
+                    EitherFuture::Left((res, fr)) => match res {
+                        Ok(Some(kv)) => ready(Ok(Some(kv))).left_future().left_future(),
+                        Err(e) => ready(Err(e)).left_future().left_future(),
+                        Ok(None) => fr.right_future().left_future(),
+                    },
+                    EitherFuture::Right((res, fl)) => match res {
+                        Ok(Some(kv)) => ready(Ok(Some(kv))).left_future().right_future(),
+                        Err(e) => ready(Err(e)).left_future().right_future(),
+                        Ok(None) => fl.right_future().right_future(),
+                    },
+                })
+                .await
         }
     }
 
-    fn delete<Q>(&self, key: &Q) -> EnqueueHandle
+    fn delete<Q>(&self, key: &Q) -> WaitHandle<impl Future<Output = Result<bool>> + Send + 'static>
     where
         Self::Key: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        match self.selector.select(key) {
-            Selection::Left => self.left.delete(key),
-            Selection::Right => self.right.delete(key),
-        }
+        let hleft = self.left.delete(key);
+        let hright = self.right.delete(key);
+        WaitHandle::new(try_join(hleft, hright).map(|res| res.map(|(l, r)| l || r)))
     }
 
     fn may_contains<Q>(&self, key: &Q) -> bool
@@ -189,10 +214,7 @@ where
         Self::Key: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        match self.selector.select(key) {
-            Selection::Left => self.left.may_contains(key),
-            Selection::Right => self.right.may_contains(key),
-        }
+        self.left.may_contains(key) || self.right.may_contains(key)
     }
 
     async fn destroy(&self) -> Result<()> {

--- a/foyer-storage/src/storage/either.rs
+++ b/foyer-storage/src/storage/either.rs
@@ -58,7 +58,6 @@ where
     }
 }
 
-#[allow(unused)]
 pub enum Selection {
     Left,
     Right,
@@ -223,8 +222,8 @@ where
     }
 
     fn stats(&self) -> std::sync::Arc<DeviceStats> {
-        // FIXME(MrCroxx): This interface needs to be refactored for it is device level stats, QwQ.
-        unimplemented!("This interface needs to be refactored for it is device level stats, QwQ.")
+        // The two engines share the same device, so it is okay to use either device stats of those.
+        self.left.stats()
     }
 
     async fn wait(&self) -> Result<()> {

--- a/foyer-storage/src/storage/runtime.rs
+++ b/foyer-storage/src/storage/runtime.rs
@@ -25,7 +25,9 @@ use crate::device::IoBuffer;
 use crate::error::Result;
 
 use crate::serde::KvInfo;
-use crate::storage::{EnqueueHandle, Storage};
+use crate::storage::Storage;
+
+use super::WaitHandle;
 
 /// The builder of the disk cache with a dedicated runtime.
 pub struct RuntimeConfigBuilder {
@@ -170,7 +172,7 @@ where
         self.runtime.spawn(future).map(|join_result| join_result.unwrap())
     }
 
-    fn delete<Q>(&self, key: &Q) -> EnqueueHandle
+    fn delete<Q>(&self, key: &Q) -> WaitHandle<impl Future<Output = Result<bool>> + Send + 'static>
     where
         Self::Key: Borrow<Q>,
         Q: Hash + Eq + ?Sized,

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -29,9 +29,9 @@ pub use memory::{CacheContext, EvictionConfig, FetchState, FifoConfig, LfuConfig
 pub use storage::{
     AdmissionPicker, AdmitAllPicker, Compression, Dev, DevExt, DevOptions, DeviceStats, DirectFileDevice,
     DirectFileDeviceOptions, DirectFileDeviceOptionsBuilder, DirectFsDevice, DirectFsDeviceOptions,
-    DirectFsDeviceOptionsBuilder, EnqueueHandle, EvictionPicker, FifoPicker, InvalidRatioPicker, RateLimitPicker,
-    RecoverMode, ReinsertionPicker, RejectAllPicker, RuntimeConfigBuilder, Storage, Store, StoreBuilder,
-    TombstoneLogConfigBuilder,
+    DirectFsDeviceOptionsBuilder, EvictionPicker, FifoPicker, InvalidRatioPicker, RateLimitPicker, RecoverMode,
+    ReinsertionPicker, RejectAllPicker, RuntimeConfigBuilder, Storage, Store, StoreBuilder, TombstoneLogConfigBuilder,
+    WaitHandle,
 };
 
 pub use crate::hybrid::{


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

This PR refined the implementation of `Either` and `Selector` to make them behave.

Changes:

- Refined `Either` and `Selector`.
- Replace `EnqueueHandle` with `WaitHandle` with more flexibilities.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#596 