### PR TITLE
feat: introduce load order for either storage

### DIFF
--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -28,6 +28,7 @@ pub use crate::{
     },
     statistics::Statistics,
     storage::{
+        either::Order,
         runtime::{RuntimeConfig, RuntimeConfigBuilder},
         Storage, WaitHandle,
     },

--- a/foyer-storage/src/storage/noop.rs
+++ b/foyer-storage/src/storage/noop.rs
@@ -18,6 +18,7 @@ use std::{borrow::Borrow, fmt::Debug, future::Future, hash::Hash, marker::Phanto
 use foyer_common::code::{HashBuilder, StorageKey, StorageValue};
 use foyer_memory::CacheEntry;
 
+use futures::future::ready;
 use futures::FutureExt;
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
@@ -98,15 +99,12 @@ where
         let _ = tx.send(Ok(false));
     }
 
-    // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
-    // False-positive with `'static` lifetime requirement.
-    #[allow(clippy::manual_async_fn)]
     fn load<Q>(&self, _: &Q) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static
     where
         Self::Key: Borrow<Q>,
         Q: Hash + Eq + ?Sized + Send + Sync + 'static,
     {
-        async move { Ok(None) }
+        ready(Ok(None))
     }
 
     fn delete<Q>(&self, _: &Q) -> WaitHandle<impl Future<Output = Result<bool>> + Send + 'static>


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

By default, the combined disk cache should query the large object disk cache first for it only includes memory access on miss for most cases, then the small object disk cache.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#596 