### PR TITLE
refactor: parallel write buffer writing for large object disk cache

### DIFF
--- a/foyer-common/src/metrics.rs
+++ b/foyer-common/src/metrics.rs
@@ -46,9 +46,8 @@ pub struct Metrics {
     pub storage_delete_duration: Histogram,
 
     pub storage_queue_rotate: Counter,
-    pub storage_queue_leader: Counter,
-    pub storage_queue_follower: Counter,
     pub storage_queue_rotate_duration: Histogram,
+    pub storage_queue_drop: Counter,
 
     pub storage_disk_write: Counter,
     pub storage_disk_read: Counter,
@@ -124,12 +123,10 @@ impl Metrics {
 
         let storage_queue_rotate =
             counter!(format!("foyer_storage_inner_op_total"), "name" => name.to_string(), "op" => "queue_rotate");
-        let storage_queue_leader =
-            counter!(format!("foyer_storage_inner_op_total"), "name" => name.to_string(), "op" => "queue_leader");
-        let storage_queue_follower =
-            counter!(format!("foyer_storage_inner_op_total"), "name" => name.to_string(), "op" => "queue_follower");
         let storage_queue_rotate_duration =
             histogram!(format!("foyer_storage_inner_op_duration"), "name" => name.to_string(), "op" => "queue_rotate");
+        let storage_queue_drop =
+            counter!(format!("foyer_storage_inner_op_total"), "name" => name.to_string(), "op" => "queue_drop");
 
         let storage_disk_write =
             counter!(format!("foyer_storage_disk_io_total"), "name" => name.to_string(), "op" => "write");
@@ -199,9 +196,8 @@ impl Metrics {
             storage_miss_duration,
             storage_delete_duration,
             storage_queue_rotate,
-            storage_queue_leader,
-            storage_queue_follower,
             storage_queue_rotate_duration,
+            storage_queue_drop,
             storage_disk_write,
             storage_disk_read,
             storage_disk_flush,

--- a/foyer-common/src/wait_group.rs
+++ b/foyer-common/src/wait_group.rs
@@ -107,6 +107,12 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn test_wait_group_empty() {
+        let wg = WaitGroup::default();
+        wg.wait().await;
+    }
+
+    #[tokio::test]
     async fn test_wait_group_basic() {
         let v = Arc::new(AtomicUsize::new(0));
         let wg = WaitGroup::default();

--- a/foyer-storage/src/large/batch.rs
+++ b/foyer-storage/src/large/batch.rs
@@ -1,0 +1,448 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use foyer_common::{
+    bits,
+    code::{HashBuilder, StorageKey, StorageValue},
+    range::RangeBoundsExt,
+    strict_assert_eq,
+    wait_group::{WaitGroup, WaitGroupFuture, WaitGroupGuard},
+};
+use foyer_memory::CacheEntry;
+use itertools::Itertools;
+use std::{
+    fmt::Debug,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut, Range},
+    time::Instant,
+};
+use tokio::sync::oneshot;
+
+use crate::{
+    device::{bytes::IoBytes, MonitoredDevice, RegionId},
+    error::Result,
+    large::indexer::HashedEntryAddress,
+    region::{GetCleanRegionHandle, RegionManager},
+    Dev, DevExt, IoBuffer,
+};
+
+use super::{
+    indexer::{EntryAddress, Indexer},
+    reclaimer::Reinsertion,
+    serde::Sequence,
+    tombstone::Tombstone,
+};
+
+pub struct Allocation {
+    _guard: WaitGroupGuard,
+    slice: ManuallyDrop<Box<[u8]>>,
+}
+
+impl Deref for Allocation {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.slice.as_ref()
+    }
+}
+
+impl DerefMut for Allocation {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.slice.as_mut()
+    }
+}
+
+impl Allocation {
+    unsafe fn new(buffer: &mut [u8], guard: WaitGroupGuard) -> Self {
+        let fake = Vec::from_raw_parts(buffer.as_mut_ptr(), buffer.len(), buffer.len());
+        let slice = ManuallyDrop::new(fake.into_boxed_slice());
+        Self { _guard: guard, slice }
+    }
+}
+
+pub struct BatchMut<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    buffer: IoBuffer,
+    len: usize,
+    groups: Vec<GroupMut<K, V, S>>,
+    tombstones: Vec<TombstoneInfo>,
+    init: Option<Instant>,
+    wait: WaitGroup,
+
+    region_manager: RegionManager,
+    device: MonitoredDevice,
+    indexer: Indexer,
+}
+
+impl<K, V, S> Debug for BatchMut<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatchMut")
+            .field("len", &self.len)
+            .field("groups", &self.groups)
+            .field("tombstones", &self.tombstones)
+            .field("init", &self.init)
+            .finish()
+    }
+}
+
+impl<K, V, S> BatchMut<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    pub fn new(capacity: usize, region_manager: RegionManager, device: MonitoredDevice, indexer: Indexer) -> Self {
+        let mut batch = Self {
+            buffer: IoBuffer::new(capacity),
+            len: 0,
+            groups: vec![],
+            tombstones: vec![],
+            init: None,
+            wait: WaitGroup::default(),
+            region_manager,
+            device,
+            indexer,
+        };
+        batch.append_group();
+        batch
+    }
+
+    pub fn entry(
+        &mut self,
+        size: usize,
+        entry: CacheEntry<K, V, S>,
+        tx: oneshot::Sender<Result<bool>>,
+        sequence: Sequence,
+    ) -> Option<Allocation> {
+        tracing::trace!("[batch]: append entry with sequence: {sequence}");
+
+        let aligned = bits::align_up(self.device.align(), size);
+
+        if entry.is_outdated() || self.len + aligned > self.buffer.len() {
+            let _ = tx.send(Ok(false));
+            return None;
+        }
+
+        self.may_init();
+        assert!(bits::is_aligned(self.device.align(), self.len));
+
+        // Rotate group if the current one is full.
+        let group = self.groups.last_mut().unwrap();
+        if group.region.offset as usize + group.region.len + aligned > self.device.region_size() {
+            group.region.is_full = true;
+            self.append_group();
+        }
+
+        let group = self.groups.last_mut().unwrap();
+        // Reserve buffer space for entry.
+        let start = self.len;
+        let end = start + aligned;
+        self.len = end;
+        group.indices.push(HashedEntryAddress {
+            hash: entry.hash(),
+            address: EntryAddress {
+                region: RegionId::MAX,
+                offset: group.region.offset as u32 + group.region.len as u32,
+                len: size as _,
+                sequence,
+            },
+        });
+        group.txs.push(tx);
+        group.entries.push(entry);
+        group.region.len += aligned;
+        group.range.end += aligned;
+
+        let allocation = unsafe { Allocation::new(&mut self.buffer[start..end], self.wait.acquire()) };
+
+        Some(allocation)
+    }
+
+    pub fn tombstone(&mut self, tombstone: Tombstone, stats: Option<InvalidStats>, tx: oneshot::Sender<Result<bool>>) {
+        tracing::trace!("[batch]: append tombstone");
+        self.may_init();
+        self.tombstones.push(TombstoneInfo { tombstone, stats, tx });
+    }
+
+    // FIXME(MrCroxx): merge into `entry`. Rename to allocate (?).
+    pub fn reinsertion(&mut self, reinsertion: &Reinsertion, tx: oneshot::Sender<Result<bool>>) -> Option<Allocation> {
+        tracing::trace!("[batch]: submit reinsertion");
+
+        let aligned = bits::align_up(self.device.align(), reinsertion.buffer.len());
+
+        // Skip if the entry is no longer in the indexer.
+        // Skip if the batch buffer size exceeds the threshold.
+        if self.indexer.get(reinsertion.hash).is_none() || self.len + aligned > self.buffer.len() {
+            let _ = tx.send(Ok(false));
+            return None;
+        }
+
+        self.may_init();
+        assert!(bits::is_aligned(self.device.align(), self.len));
+
+        // Rotate group if the current one is full.
+        let group = self.groups.last_mut().unwrap();
+        if group.region.offset as usize + group.region.len + aligned > self.device.region_size() {
+            group.region.is_full = true;
+            self.append_group();
+        }
+
+        let group = self.groups.last_mut().unwrap();
+        // Reserve buffer space for entry.
+        let start = self.len;
+        let end = start + aligned;
+        self.len = end;
+        group.indices.push(HashedEntryAddress {
+            hash: reinsertion.hash,
+            address: EntryAddress {
+                region: RegionId::MAX,
+                offset: group.region.offset as u32 + group.region.len as u32,
+                len: reinsertion.buffer.len() as _,
+                sequence: reinsertion.sequence,
+            },
+        });
+        group.txs.push(tx);
+        group.region.len += aligned;
+        group.range.end += aligned;
+
+        let allocation = unsafe { Allocation::new(&mut self.buffer[start..end], self.wait.acquire()) };
+
+        Some(allocation)
+    }
+
+    pub fn rotate(&mut self) -> Option<(Batch<K, V, S>, WaitGroupFuture)> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let mut buffer = IoBuffer::new(self.buffer.len());
+        std::mem::swap(&mut self.buffer, &mut buffer);
+        self.len = 0;
+        let buffer = IoBytes::from(buffer);
+
+        let wait = std::mem::take(&mut self.wait);
+
+        let init = self.init.take();
+
+        let tombstones = std::mem::take(&mut self.tombstones);
+
+        let next = self.groups.last().map(|last| {
+            assert!(!last.region.is_full);
+            let next = GroupMut {
+                region: RegionHandle {
+                    handle: last.region.handle.clone(),
+                    offset: last.region.offset + last.region.len as u64,
+                    len: 0,
+                    is_full: false,
+                },
+                indices: vec![],
+                txs: vec![],
+                entries: vec![],
+                range: 0..0,
+            };
+            tracing::trace!("[batch]: try to reuse the last region with: {next:?}");
+            next
+        });
+
+        let groups = self
+            .groups
+            .drain(..)
+            .map(|group| {
+                // TODO(MrCroxx): Refine to logic.
+                // Do not filter empty group here.
+                // An empty group can be used to trigger makring evictable region in flusher.
+                strict_assert_eq!(group.region.len, group.range.size().unwrap());
+                Group {
+                    region: group.region,
+                    bytes: buffer.slice(group.range),
+                    indices: group.indices,
+                    txs: group.txs,
+                    entries: group.entries,
+                }
+            })
+            .collect_vec();
+
+        match next {
+            Some(next) => self.groups.push(next),
+            None => self.append_group(),
+        }
+
+        Some((
+            Batch {
+                groups,
+                tombstones,
+                init,
+            },
+            wait.wait(),
+        ))
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tombstones.is_empty() && self.groups.iter().all(|group| group.range.is_empty())
+    }
+
+    fn may_init(&mut self) {
+        if self.init.is_none() {
+            self.init = Some(Instant::now());
+        }
+    }
+
+    fn append_group(&mut self) {
+        self.groups.push(GroupMut {
+            region: RegionHandle {
+                handle: self.region_manager.get_clean_region(),
+                offset: 0,
+                len: 0,
+                is_full: false,
+            },
+            indices: vec![],
+            txs: vec![],
+            entries: vec![],
+            range: self.len..self.len,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidStats {
+    pub region: RegionId,
+    pub size: usize,
+}
+
+pub struct RegionHandle {
+    /// Handle of the region to write.
+    pub handle: GetCleanRegionHandle,
+    /// Offoset of the region to write.
+    pub offset: u64,
+    /// Length of the buffer to write.
+    pub len: usize,
+    /// If the region was full.
+    pub is_full: bool,
+}
+
+impl Debug for RegionHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegionHandle")
+            .field("offset", &self.offset)
+            .field("size", &self.len)
+            .field("is_full", &self.is_full)
+            .finish()
+    }
+}
+
+struct GroupMut<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    /// Reusable Clean region handle.
+    region: RegionHandle,
+    /// Entry indices to be inserted.
+    indices: Vec<HashedEntryAddress>,
+    /// Writer notify tx.
+    txs: Vec<oneshot::Sender<Result<bool>>>,
+    /// Hold entries until flush finishes to avoid in-memory cache lookup miss.
+    entries: Vec<CacheEntry<K, V, S>>,
+    /// Tracks the group bytes range of the batch buffer.
+    range: Range<usize>,
+}
+
+impl<K, V, S> Debug for GroupMut<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Group")
+            .field("handle", &self.region)
+            .field("indices", &self.indices)
+            .field("range", &self.range)
+            .finish()
+    }
+}
+
+pub struct Group<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    /// Reusable Clean region handle.
+    pub region: RegionHandle,
+    /// Buffer to flush.
+    pub bytes: IoBytes,
+    /// Entry indices to be inserted.
+    pub indices: Vec<HashedEntryAddress>,
+    /// Writer notify tx.
+    pub txs: Vec<oneshot::Sender<Result<bool>>>,
+    /// Hold entries until flush finishes to avoid in-memory cache lookup miss.
+    pub entries: Vec<CacheEntry<K, V, S>>,
+}
+
+impl<K, V, S> Debug for Group<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Group")
+            .field("handle", &self.region)
+            .field("indices", &self.indices)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct TombstoneInfo {
+    pub tombstone: Tombstone,
+    pub stats: Option<InvalidStats>,
+    pub tx: oneshot::Sender<Result<bool>>,
+}
+
+pub struct Batch<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    pub groups: Vec<Group<K, V, S>>,
+    pub tombstones: Vec<TombstoneInfo>,
+    pub init: Option<Instant>,
+}
+
+impl<K, V, S> Debug for Batch<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Batch")
+            .field("groups", &self.groups)
+            .field("tombstones", &self.tombstones)
+            .field("init", &self.init)
+            .finish()
+    }
+}

--- a/foyer-storage/src/large/flusher.rs
+++ b/foyer-storage/src/large/flusher.rs
@@ -13,46 +13,38 @@
 //  limitations under the License.
 
 use crate::{
-    device::{MonitoredDevice, RegionId},
+    device::MonitoredDevice,
     error::{Error, Result},
     large::serde::EntryHeader,
-    region::{GetCleanRegionHandle, RegionManager},
+    region::RegionManager,
     serde::{Checksummer, KvInfo},
-    Compression, IoBytes, IoBytesMut, Statistics,
+    Compression, IoBytes, Statistics,
 };
 use foyer_common::{
-    bits,
     code::{HashBuilder, StorageKey, StorageValue},
     metrics::Metrics,
-    strict_assert, strict_assert_eq,
+    strict_assert,
 };
 use foyer_memory::CacheEntry;
 use futures::future::{try_join, try_join_all};
+use parking_lot::Mutex;
 use std::{
     fmt::Debug,
     sync::{atomic::Ordering, Arc},
-    time::Instant,
 };
 use tokio::{
     runtime::Handle,
-    sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore},
+    sync::{oneshot, Notify, Semaphore},
 };
 
-use crate::{Dev, DevExt};
-
 use super::{
+    batch::{Batch, BatchMut, InvalidStats, TombstoneInfo},
     generic::GenericLargeStorageConfig,
-    indexer::{EntryAddress, Indexer},
+    indexer::Indexer,
     reclaimer::Reinsertion,
     serde::Sequence,
     tombstone::{Tombstone, TombstoneLog},
 };
-
-#[derive(Debug)]
-pub struct InvalidStats {
-    pub region: RegionId,
-    pub size: usize,
-}
 
 #[derive(Debug)]
 pub enum Submission<K, V, S>
@@ -79,64 +71,6 @@ where
     },
 }
 
-struct WriteGroup<K, V, S>
-where
-    K: StorageKey,
-    V: StorageValue,
-    S: HashBuilder,
-{
-    writer: RegionHandle,
-
-    buffer: IoBytesMut,
-    indices: Vec<(u64, EntryAddress)>,
-    txs: Vec<oneshot::Sender<Result<bool>>>,
-    // hold the entries to avoid memory cache lookup miss?
-    entries: Vec<CacheEntry<K, V, S>>,
-}
-
-impl<K, V, S> Debug for WriteGroup<K, V, S>
-where
-    K: StorageKey,
-    V: StorageValue,
-    S: HashBuilder,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WriteGroup")
-            .field("writer", &self.writer)
-            .field("buffer_len", &self.buffer.len())
-            .field("indices", &self.indices)
-            .finish()
-    }
-}
-
-struct RegionHandle {
-    handle: GetCleanRegionHandle,
-    offset: u64,
-    size: usize,
-    is_full: bool,
-}
-
-impl Debug for RegionHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RegionHandle")
-            .field("offset", &self.offset)
-            .field("size", &self.size)
-            .field("is_full", &self.is_full)
-            .finish()
-    }
-}
-
-impl Clone for RegionHandle {
-    fn clone(&self) -> Self {
-        Self {
-            handle: self.handle.clone(),
-            offset: self.offset,
-            size: self.size,
-            is_full: self.is_full,
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct Flusher<K, V, S>
 where
@@ -144,10 +78,13 @@ where
     V: StorageValue,
     S: HashBuilder + Debug,
 {
-    tx: mpsc::UnboundedSender<Submission<K, V, S>>,
+    batch: Arc<Mutex<BatchMut<K, V, S>>>,
+
+    notify: Arc<Notify>,
 
     flight: Arc<Semaphore>,
 
+    compression: Compression,
     metrics: Arc<Metrics>,
 }
 
@@ -159,8 +96,10 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            tx: self.tx.clone(),
+            batch: self.batch.clone(),
+            notify: self.notify.clone(),
             flight: self.flight.clone(),
+            compression: self.compression,
             metrics: self.metrics.clone(),
         }
     }
@@ -184,24 +123,27 @@ where
         metrics: Arc<Metrics>,
         runtime: Handle,
     ) -> Result<Self> {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let batch = Batch::default();
+        let notify = Arc::new(Notify::new());
+
+        let buffer_size = config.buffer_threshold / config.flushers;
+        let batch = Arc::new(Mutex::new(BatchMut::new(
+            buffer_size,
+            region_manager.clone(),
+            device.clone(),
+            indexer.clone(),
+        )));
+
         let flight = Arc::new(Semaphore::new(1));
 
         let runner = Runner {
-            batch,
-            rx,
+            batch: batch.clone(),
+            notify: notify.clone(),
             region_manager,
             indexer,
-            device,
             tombstone_log,
-            compression: config.compression,
             flush: config.flush,
             stats,
             metrics: metrics.clone(),
-            runtime: runtime.clone(),
-            flight: flight.clone(),
-            threshold: config.buffer_threshold / config.flushers,
         };
 
         runtime.spawn(async move {
@@ -210,121 +152,16 @@ where
             }
         });
 
-        Ok(Self { tx, flight, metrics })
+        Ok(Self {
+            batch,
+            notify,
+            flight,
+            compression: config.compression,
+            metrics,
+        })
     }
 
     pub fn submit(&self, submission: Submission<K, V, S>) {
-        if let Err(e) = self.tx.send(submission) {
-            tracing::warn!("[flusher]: submit error, e: {e}");
-        }
-    }
-
-    pub async fn wait(&self) -> Result<()> {
-        // TODO(MrCroxx): Consider a better implementation?
-        let _permit = self.flight.acquire().await;
-        Ok(())
-    }
-}
-
-struct Batch<K, V, S>
-where
-    K: StorageKey,
-    V: StorageValue,
-    S: HashBuilder + Debug,
-{
-    groups: Vec<WriteGroup<K, V, S>>,
-    tombstones: Vec<(Tombstone, Option<InvalidStats>, oneshot::Sender<Result<bool>>)>,
-    init_time: Option<Instant>,
-}
-
-impl<K, V, S> Debug for Batch<K, V, S>
-where
-    K: StorageKey,
-    V: StorageValue,
-    S: HashBuilder + Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Batch").field("groups", &self.groups).finish()
-    }
-}
-
-impl<K, V, S> Default for Batch<K, V, S>
-where
-    K: StorageKey,
-    V: StorageValue,
-    S: HashBuilder + Debug,
-{
-    fn default() -> Self {
-        Self {
-            groups: vec![],
-            tombstones: vec![],
-            init_time: None,
-        }
-    }
-}
-
-impl<K, V, S> Batch<K, V, S>
-where
-    K: StorageKey,
-    V: StorageValue,
-    S: HashBuilder + Debug,
-{
-    fn buffer_size(&self) -> usize {
-        self.groups.iter().map(|group| group.buffer.len()).sum()
-    }
-}
-
-struct Runner<K, V, S>
-where
-    K: StorageKey,
-    V: StorageValue,
-    S: HashBuilder + Debug,
-{
-    batch: Batch<K, V, S>,
-
-    rx: mpsc::UnboundedReceiver<Submission<K, V, S>>,
-
-    region_manager: RegionManager,
-    indexer: Indexer,
-    device: MonitoredDevice,
-    tombstone_log: Option<TombstoneLog>,
-
-    compression: Compression,
-    flush: bool,
-    threshold: usize,
-
-    stats: Arc<Statistics>,
-    metrics: Arc<Metrics>,
-
-    runtime: Handle,
-
-    flight: Arc<Semaphore>,
-}
-
-impl<K, V, S> Runner<K, V, S>
-where
-    K: StorageKey,
-    V: StorageValue,
-    S: HashBuilder + Debug,
-{
-    pub async fn run(mut self) -> Result<()> {
-        loop {
-            let flight = self.flight.clone();
-            tokio::select! {
-                biased;
-                Ok(permit) = flight.acquire_owned(), if self.batch.init_time.is_some() => {
-                    self.commit(permit);
-                }
-                Some(submission) = self.rx.recv() => {
-                    self.submission(submission);
-                }
-                else => break,
-            }
-        }
-        Ok(())
-    }
-
-    fn submission(&mut self, submission: Submission<K, V, S>) {
         match submission {
             Submission::CacheEntry {
                 entry,
@@ -336,43 +173,23 @@ where
             Submission::Tombstone { tombstone, stats, tx } => self.tombstone(tombstone, stats, tx),
             Submission::Reinsertion { reinsertion, tx } => self.reinsertion(reinsertion, tx),
         }
+        self.notify.notify_one();
     }
 
-    fn tombstone(&mut self, tombstone: Tombstone, stats: Option<InvalidStats>, tx: oneshot::Sender<Result<bool>>) {
-        tracing::trace!("[flusher]: submit tombstone");
-        self.may_init_batch_state();
-        self.batch.tombstones.push((tombstone, stats, tx));
+    pub async fn wait(&self) -> Result<()> {
+        // TODO(MrCroxx): Consider a better implementation?
+        let _permit = self.flight.acquire().await;
+        Ok(())
     }
 
     fn entry(
-        &mut self,
+        &self,
         entry: CacheEntry<K, V, S>,
         buffer: IoBytes,
         info: KvInfo,
-        sequence: Sequence,
+        sequence: u64,
         tx: oneshot::Sender<Result<bool>>,
     ) {
-        tracing::trace!("[flusher]: submit entry with sequence: {sequence}");
-
-        // Skip if the entry is already outdated.
-        // Skip if the batch buffer size exceeds the threshold.
-        if entry.is_outdated() || self.batch.buffer_size() > self.threshold {
-            let _ = tx.send(Ok(false));
-            return;
-        }
-
-        self.may_init_batch_state();
-        if self.batch.init_time.is_none() {
-            self.batch.init_time = Some(Instant::now());
-        }
-
-        // Attempt to pick the latest group to write.
-        let group = self.batch.groups.last_mut().unwrap();
-
-        // Write to the latest group and check aligns.
-        bits::debug_assert_aligned(self.device.align(), group.buffer.len());
-        let mut boffset = group.buffer.len();
-
         let header = EntryHeader {
             key_len: info.key_len as _,
             value_len: info.value_len as _,
@@ -382,255 +199,158 @@ where
             compression: self.compression,
         };
 
-        group
-            .buffer
-            .reserve(bits::align_up(self.device.align(), header.entry_len()));
-        // TODO(MrCroxx): impl `BufMut` for `WritableVecA` to avoid manually reservation?
-        unsafe { group.buffer.set_len(boffset + EntryHeader::serialized_len()) };
-        header.write(&mut group.buffer[boffset..]);
-        group.buffer.extend_from_slice(&buffer);
+        let mut allocation = match self.batch.lock().entry(header.entry_len(), entry, tx, sequence) {
+            Some(allocation) => allocation,
+            None => {
+                self.metrics.storage_queue_drop.increment(1);
+                return;
+            }
+        };
+        strict_assert!(allocation.len() > header.entry_len());
 
-        let len = group.buffer.len() - boffset;
-        let aligned = bits::align_up(self.device.align(), len);
-        strict_assert!(group.buffer.capacity() >= boffset + aligned);
-        unsafe { group.buffer.set_len(boffset + aligned) };
-
-        bits::debug_assert_aligned(self.device.align(), group.buffer.len());
-        tracing::trace!(
-            "[flusher]: sequence: {sequence}, len: {len}, aligned: {aligned}, buf len: {buf_len}",
-            buf_len = group.buffer.len()
-        );
-
-        // Split the latest group if it exceeds the current region.
-        if group.writer.offset as usize + group.buffer.len() > self.device.region_size() {
-            tracing::trace!("[flusher]: (sequence: {sequence}) split group at size: {size}, buf len: {buf_len}, total (if not split): {total}, exceeds region size: {region_size}",
-                    size = group.writer.size,
-                    buf_len = group.buffer.len(),
-                    total = group.writer.offset as usize + group.buffer.len() ,
-                    region_size = self.device.region_size(),
-                );
-
-            group.writer.is_full = true;
-
-            let buffer = group.buffer.split_off(boffset);
-
-            bits::debug_assert_aligned(self.device.align(), group.buffer.len());
-            bits::debug_assert_aligned(self.device.align(), buffer.len());
-
-            self.append_groups_with_buffer(buffer);
-            boffset = 0;
-        }
-
-        // Re-reference the latest group in case it may be out-dated.
-        let group = self.batch.groups.last_mut().unwrap();
-        group.indices.push((
-            entry.hash(),
-            EntryAddress {
-                region: RegionId::MAX,
-                offset: group.writer.offset as u32 + boffset as u32,
-                len: len as _,
-                sequence,
-            },
-        ));
-        group.txs.push(tx);
-        group.entries.push(entry);
-        group.writer.size += aligned;
+        header.write(&mut allocation[0..EntryHeader::serialized_len()]);
+        allocation[EntryHeader::serialized_len()..header.entry_len()].copy_from_slice(&buffer);
     }
 
-    fn reinsertion(&mut self, reinsertion: Reinsertion, tx: oneshot::Sender<Result<bool>>) {
-        tracing::trace!("[flusher]: submit reinsertion");
-
-        // Skip if the entry is no longer in the indexer.
-        // Skip if the batch buffer size exceeds the threshold.
-        if self.indexer.get(reinsertion.hash).is_none() || self.batch.buffer_size() > self.threshold {
-            let _ = tx.send(Ok(false));
-            return;
-        }
-
-        self.may_init_batch_state();
-        if self.batch.init_time.is_none() {
-            self.batch.init_time = Some(Instant::now());
-        }
-
-        // Attempt to pick the latest group to write.
-        let group = self.batch.groups.last_mut().unwrap();
-        bits::debug_assert_aligned(self.device.align(), group.buffer.len());
-
-        // Rotate group early for we know the len of the buffer to write.
-        let aligned = bits::align_up(self.device.align(), reinsertion.buffer.len());
-        if group.writer.offset as usize + group.buffer.len() + aligned > self.device.region_size() {
-            tracing::trace!("[flusher]: split group at size: {size}, acc buf len: {acc_buf_len}, buf len: {buf_len}, total (if not split): {total}, exceeds region size: {region_size}",
-                    size = group.writer.size,
-                    acc_buf_len = group.buffer.len(),
-                    buf_len = reinsertion.buffer.len(),
-                    total = group.writer.offset as usize + group.buffer.len() + reinsertion.buffer.len(),
-                    region_size = self.device.region_size(),
-                );
-
-            group.writer.is_full = true;
-
-            bits::debug_assert_aligned(self.device.align(), group.buffer.len());
-
-            self.append_groups();
-        }
-
-        // Re-reference the latest group in case it may be out-dated.
-        let group = self.batch.groups.last_mut().unwrap();
-        let boffset = group.buffer.len();
-        let len = reinsertion.buffer.len();
-        group.buffer.reserve(aligned);
-        group.buffer.extend_from_slice(&reinsertion.buffer);
-        unsafe { group.buffer.set_len(boffset + aligned) };
-        group.indices.push((
-            reinsertion.hash,
-            EntryAddress {
-                region: RegionId::MAX,
-                offset: group.writer.offset as u32 + boffset as u32,
-                len: len as _,
-                sequence: reinsertion.sequence,
-            },
-        ));
-        group.txs.push(tx);
-        group.writer.size += aligned;
+    fn tombstone(&self, tombstone: Tombstone, stats: Option<InvalidStats>, tx: oneshot::Sender<Result<bool>>) {
+        self.batch.lock().tombstone(tombstone, stats, tx);
     }
 
-    fn commit(&mut self, permit: OwnedSemaphorePermit) {
-        // Rotate batch.
-        tracing::trace!("[flusher]: create new batch based on old batch: {:?}", self.batch);
+    fn reinsertion(&self, reinsertion: Reinsertion, tx: oneshot::Sender<Result<bool>>) {
+        let mut allocation = match self.batch.lock().reinsertion(&reinsertion, tx) {
+            Some(allocation) => allocation,
+            None => {
+                self.metrics.storage_queue_drop.increment(1);
+                return;
+            }
+        };
+        strict_assert!(allocation.len() > reinsertion.buffer.len());
+        allocation[0..reinsertion.buffer.len()].copy_from_slice(&reinsertion.buffer);
+    }
+}
 
-        let mut batch = Batch::default();
+struct Runner<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    batch: Arc<Mutex<BatchMut<K, V, S>>>,
 
-        if let Some(group) = self.batch.groups.last() {
-            let mut writer = group.writer.clone();
-            strict_assert_eq!(
-                writer.offset as usize + group.buffer.len(),
-                writer.size,
-                "offset ({offset}) + buffer len ({buf_len}) = total ({total}) != size ({size})",
-                offset = writer.offset,
-                buf_len = group.buffer.len(),
-                total = writer.offset as usize + group.buffer.len(),
-                size = writer.size,
-            );
-            writer.offset = writer.size as u64;
-            batch.groups.push(WriteGroup {
-                writer,
-                buffer: IoBytesMut::with_capacity(self.device.region_size()),
-                indices: vec![],
-                txs: vec![],
-                entries: vec![],
-            });
-        }
-        std::mem::swap(&mut self.batch, &mut batch);
+    notify: Arc<Notify>,
 
-        // Commit batch.
+    region_manager: RegionManager,
+    indexer: Indexer,
+    tombstone_log: Option<TombstoneLog>,
 
-        let indexer = self.indexer.clone();
-        let flush = self.flush;
-        let region_manager = self.region_manager.clone();
-        let tombstone_log: Option<TombstoneLog> = self.tombstone_log.clone();
-        let stats = self.stats.clone();
-        let metrics = self.metrics.clone();
+    flush: bool,
 
-        self.runtime.spawn(async move {
-            // Write regions concurrently.
-            let futures = batch.groups.into_iter().map(|group| {
-                let indexer = indexer.clone();
-                let region_manager = region_manager.clone();
-                let stats = stats.clone();
-                async move {
-                    // Wait for region is clean.
-                    let region = group.writer.handle.await;
-                    tracing::trace!(
-                        "[flusher]: write region: {id}, at offset: {offset}, buffer len: {buf_len}",
-                        id = region.id(),
-                        offset = group.writer.size,
-                        buf_len = group.buffer.len(),
-                    );
-                    // Write buffet to device.
-                    if !group.buffer.is_empty() {
-                        let aligned = group.buffer.len();
-                        region.write(group.buffer.freeze(), group.writer.offset).await?;
-                        if flush {
-                            region.flush().await?;
-                        }
-                        stats.cache_write_bytes.fetch_add(aligned, Ordering::Relaxed);
-                        let mut indices = group.indices;
-                        for (_, addr) in indices.iter_mut() {
-                            addr.region = region.id();
-                        }
-                        indexer.insert_batch(indices);
-                        for tx in group.txs {
-                            let _ = tx.send(Ok(true));
-                        }
-                    }
-                    if group.writer.is_full {
-                        region_manager.mark_evictable(region.id());
-                    }
-                    // Make sure entries are dropped after written.
-                    drop(group.entries);
-                    tracing::trace!("[flusher]: write region {id} finish.", id = region.id());
-                    Ok::<_, Error>(())
-                }
-            });
-            let future = {
-                let tombstones = batch.tombstones;
-                let has_tombstone_log = tombstone_log.is_some();
-                let region_manager = region_manager.clone();
-                let tombstone_log = tombstone_log.clone();
-                async move {
-                    if let Some(log) = tombstone_log {
-                        log.append(tombstones.iter().map(|(tombstone, _, _)| tombstone)).await?;
-                    }
-                    for (_, stats, tx) in tombstones {
-                        if let Some(stats) = stats {
-                            region_manager
-                                .region(stats.region)
-                                .stats()
-                                .invalid
-                                .fetch_add(stats.size, Ordering::Relaxed);
-                        }
-                        let _ = tx.send(Ok(has_tombstone_log));
-                    }
-                    Ok::<_, Error>(())
+    stats: Arc<Statistics>,
+    metrics: Arc<Metrics>,
+}
+
+impl<K, V, S> Runner<K, V, S>
+where
+    K: StorageKey,
+    V: StorageValue,
+    S: HashBuilder + Debug,
+{
+    pub async fn run(self) -> Result<()> {
+        // TODO(MrCroxx): Graceful shutdown.
+        loop {
+            let rotation = self.batch.lock().rotate();
+            let (batch, wait) = match rotation {
+                Some(rotation) => rotation,
+                None => {
+                    self.notify.notified().await;
+                    continue;
                 }
             };
-            try_join(try_join_all(futures), future).await?;
-            if let Some(init_time) = batch.init_time.as_ref() {
-                metrics.storage_queue_rotate.increment(1);
-                metrics.storage_queue_rotate_duration.record(init_time.elapsed());
+
+            wait.await;
+
+            self.commit(batch).await
+        }
+    }
+
+    async fn commit(&self, batch: Batch<K, V, S>) {
+        tracing::trace!("[flusher] commit batch: {batch:?}");
+
+        // Write regions concurrently.
+        let futures = batch.groups.into_iter().map(|group| {
+            let indexer = self.indexer.clone();
+            let region_manager = self.region_manager.clone();
+            let stats = self.stats.clone();
+            async move {
+                // Wait for region is clean.
+                let region = group.region.handle.await;
+                tracing::trace!(
+                    "[flusher]: write region: {id}, at offset: {offset}, buffer len: {buf_len}",
+                    id = region.id(),
+                    offset = group.region.offset,
+                    buf_len = group.bytes.len(),
+                );
+
+                // Write buffer to device.
+                let size: usize = group.bytes.len();
+                if size > 0 {
+                    region.write(group.bytes, group.region.offset).await?;
+                    if self.flush {
+                        region.flush().await?;
+                    }
+                    stats.cache_write_bytes.fetch_add(size, Ordering::Relaxed);
+                }
+                let mut indices = group.indices;
+                for haddr in indices.iter_mut() {
+                    haddr.address.region = region.id();
+                }
+                indexer.insert_batch(indices);
+                for tx in group.txs {
+                    let _ = tx.send(Ok(true));
+                }
+
+                if group.region.is_full {
+                    region_manager.mark_evictable(region.id());
+                }
+                // Make sure entries are dropped after written.
+                drop(group.entries);
+                tracing::trace!("[flusher]: write region {id} finish.", id = region.id());
+                Ok::<_, Error>(())
             }
-            drop(permit);
-            Ok::<_, Error>(())
         });
-    }
-
-    /// Initialize the batch state if needed.
-    fn may_init_batch_state(&mut self) {
-        if self.batch.init_time.is_none() {
-            self.batch.init_time = Some(Instant::now());
+        let future = {
+            let tombstones = batch.tombstones;
+            let has_tombstone_log = self.tombstone_log.is_some();
+            let region_manager = self.region_manager.clone();
+            let tombstone_log = self.tombstone_log.clone();
+            async move {
+                if let Some(log) = tombstone_log {
+                    log.append(tombstones.iter().map(|info| &info.tombstone)).await?;
+                }
+                for TombstoneInfo {
+                    tombstone: _,
+                    stats,
+                    tx,
+                } in tombstones
+                {
+                    if let Some(stats) = stats {
+                        region_manager
+                            .region(stats.region)
+                            .stats()
+                            .invalid
+                            .fetch_add(stats.size, Ordering::Relaxed);
+                    }
+                    let _ = tx.send(Ok(has_tombstone_log));
+                }
+                Ok::<_, Error>(())
+            }
+        };
+        if let Err(e) = try_join(try_join_all(futures), future).await {
+            tracing::error!("[flusher]: error raised when committing batch, error: {e}");
         }
-        if self.batch.groups.is_empty() {
-            self.append_groups();
+        if let Some(init) = batch.init.as_ref() {
+            self.metrics.storage_queue_rotate.increment(1);
+            self.metrics.storage_queue_rotate_duration.record(init.elapsed());
         }
-    }
-
-    fn append_groups(&mut self) {
-        self.append_groups_with_buffer(IoBytesMut::with_capacity(self.device.region_size()));
-    }
-
-    fn append_groups_with_buffer(&mut self, buffer: IoBytesMut) {
-        let handle = self.region_manager.get_clean_region();
-        self.batch.groups.push(WriteGroup {
-            writer: RegionHandle {
-                handle,
-                offset: 0,
-                size: 0,
-                is_full: false,
-            },
-            buffer,
-            indices: vec![],
-            txs: vec![],
-            entries: vec![],
-        });
     }
 }

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -59,7 +59,8 @@ use tokio::{
 };
 
 use super::{
-    flusher::{Flusher, InvalidStats, Submission},
+    batch::InvalidStats,
+    flusher::{Flusher, Submission},
     indexer::Indexer,
     reclaimer::Reclaimer,
     recover::{RecoverMode, RecoverRunner},
@@ -611,7 +612,7 @@ mod tests {
             eviction_pickers: vec![Box::<FifoPicker>::default()],
             reinsertion_picker,
             tombstone_log_config: None,
-            buffer_threshold: usize::MAX,
+            buffer_threshold: 16 * 1024 * 1024,
             statistics: Arc::<Statistics>::default(),
         };
         GenericLargeStorage::open(config).await.unwrap()
@@ -640,7 +641,7 @@ mod tests {
             eviction_pickers: vec![Box::<FifoPicker>::default()],
             reinsertion_picker: Arc::<RejectAllPicker<u64>>::default(),
             tombstone_log_config: Some(TombstoneLogConfigBuilder::new(path).with_flush(true).build()),
-            buffer_threshold: usize::MAX,
+            buffer_threshold: 16 * 1024 * 1024,
             statistics: Arc::<Statistics>::default(),
         };
         GenericLargeStorage::open(config).await.unwrap()
@@ -902,6 +903,7 @@ mod tests {
         }
         let mut res = vec![];
         for i in 0..8 {
+            tracing::trace!("==========> {i}");
             res.push(store.load(&i).await.unwrap());
         }
         assert_eq!(

--- a/foyer-storage/src/large/indexer.rs
+++ b/foyer-storage/src/large/indexer.rs
@@ -22,6 +22,12 @@ use parking_lot::RwLock;
 
 use crate::{device::RegionId, large::serde::Sequence};
 
+#[derive(Debug)]
+pub struct HashedEntryAddress {
+    pub hash: u64,
+    pub address: EntryAddress,
+}
+
 #[derive(Debug, Clone)]
 pub struct EntryAddress {
     pub region: RegionId,
@@ -46,16 +52,19 @@ impl Indexer {
     }
 
     #[minitrace::trace(name = "foyer::storage::large::indexer::insert_batch")]
-    pub fn insert_batch(&self, batch: Vec<(u64, EntryAddress)>) -> Vec<(u64, EntryAddress)> {
-        let shards: HashMap<usize, Vec<(u64, EntryAddress)>> =
-            batch.into_iter().into_group_map_by(|(hash, _)| self.shard(*hash));
+    pub fn insert_batch(&self, batch: Vec<HashedEntryAddress>) -> Vec<HashedEntryAddress> {
+        let shards: HashMap<usize, Vec<HashedEntryAddress>> =
+            batch.into_iter().into_group_map_by(|haddr| self.shard(haddr.hash));
 
         let mut olds = vec![];
         for (s, batch) in shards {
             let mut shard = self.shards[s].write();
-            for (hash, addr) in batch {
-                if let Some(old) = self.insert_inner(&mut shard, hash, addr) {
-                    olds.push((hash, old));
+            for haddr in batch {
+                if let Some(old) = self.insert_inner(&mut shard, haddr.hash, haddr.address) {
+                    olds.push(HashedEntryAddress {
+                        hash: haddr.hash,
+                        address: old,
+                    });
                 }
             }
         }

--- a/foyer-storage/src/large/mod.rs
+++ b/foyer-storage/src/large/mod.rs
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+pub mod batch;
 pub mod flusher;
 pub mod generic;
 pub mod indexer;

--- a/foyer-storage/src/large/recover.rs
+++ b/foyer-storage/src/large/recover.rs
@@ -28,6 +28,7 @@ use tokio::sync::Semaphore;
 
 use crate::error::{Error, Result};
 
+use crate::large::indexer::HashedEntryAddress;
 use crate::large::{
     scanner::{EntryInfo, RegionScanner},
     serde::{AtomicSequence, Sequence},
@@ -137,7 +138,9 @@ impl RecoverRunner {
                 match versions.pop() {
                     None => None,
                     Some((_, EntryAddressOrTombstone::Tombstone)) => None,
-                    Some((_, EntryAddressOrTombstone::EntryAddress(addr))) => Some((hash, addr)),
+                    Some((_, EntryAddressOrTombstone::EntryAddress(address))) => {
+                        Some(HashedEntryAddress { hash, address })
+                    }
                 }
             })
             .collect_vec();

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -15,7 +15,7 @@
 pub use crate::{
     compress::Compression,
     device::{
-        bytes::{IoBytes, IoBytesMut},
+        bytes::{IoBuffer, IoBytes, IoBytesMut},
         direct_file::{DirectFileDevice, DirectFileDeviceOptions, DirectFileDeviceOptionsBuilder},
         direct_fs::{DirectFsDevice, DirectFsDeviceOptions, DirectFsDeviceOptionsBuilder},
         monitor::DeviceStats,

--- a/foyer-storage/src/storage/runtime.rs
+++ b/foyer-storage/src/storage/runtime.rs
@@ -278,7 +278,7 @@ mod tests {
             eviction_pickers: vec![Box::<FifoPicker>::default()],
             reinsertion_picker: Arc::<RejectAllPicker<u64>>::default(),
             tombstone_log_config: None,
-            buffer_threshold: usize::MAX,
+            buffer_threshold: 16 * 1024 * 1024,
             statistics: Arc::<Statistics>::default(),
         }
     }

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -291,6 +291,7 @@ where
     recover_concurrency: usize,
     flushers: usize,
     reclaimers: usize,
+    // FIXME(MrCroxx): rename the field and builder fn.
     buffer_threshold: usize,
     clean_region_threshold: Option<usize>,
     eviction_pickers: Vec<Box<dyn EvictionPicker>>,
@@ -321,7 +322,7 @@ where
             recover_concurrency: 8,
             flushers: 1,
             reclaimers: 1,
-            buffer_threshold: usize::MAX,
+            buffer_threshold: 16 * 1024 * 1024, // 16 MiB
             clean_region_threshold: None,
             eviction_pickers: vec![Box::new(InvalidRatioPicker::new(0.8)), Box::<FifoPicker>::default()],
             admission_picker: Arc::<AdmitAllPicker<K>>::default(),

--- a/foyer/src/hybrid/builder.rs
+++ b/foyer/src/hybrid/builder.rs
@@ -305,7 +305,7 @@ where
     ///
     /// If the buffer of the flush queue exceeds the threshold, the further entries will be ignored.
     ///
-    /// Default: No Limits.
+    /// Default: 16 MiB.
     pub fn with_buffer_threshold(self, threshold: usize) -> Self {
         let builder = self.builder.with_buffer_threshold(threshold);
         Self {


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

This PR refined the write model of the large object disk cache.

With the previous design, entries submitted to the same flusher will be serialized in the flusher runner thread (tokio task), whose throughput is limited by the 1 CPU core. With the new design, every entry is serialized in its submit thread, and the serialization between entries can be paralleled.

The parallelism is achieved by allocating with a mutex and waiting with`WaitGroup` #615. 

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#596 #615 
close #581 