### PR TITLE
perf: reduce page fault when writing disk cache io buffer

### DIFF
--- a/foyer-storage/src/device/bytes.rs
+++ b/foyer-storage/src/device/bytes.rs
@@ -413,6 +413,24 @@ impl IoBytes {
         debug_assert_eq!(end % ALIGN, 0);
         &self.inner[start..end]
     }
+
+    /// Returns the underlying buffer as [`IoBuffer`], if the [`IoBytes`] has exactly one reference.
+    ///
+    /// Otherwise, an [`Err`] is returned with the same [`IoBytes`] that was passed in.
+    ///
+    /// Note: The [`IoBytes`] can be a slice of the underlying [`IoBuffer`].
+    /// `try_into_io_buffer` always returns the original complete underlying [`IoBuffer`].
+    pub fn try_into_io_buffer(self) -> core::result::Result<IoBuffer, Self> {
+        // TODO(MrCroxx): Add `into_io_buffer` with `Arc::into_inner`. See `Arc::try_unwrap` docs.
+        match Arc::try_unwrap(self.inner) {
+            Ok(inner) => Ok(IoBuffer { inner }),
+            Err(inner) => Err(Self {
+                inner,
+                offset: self.offset,
+                len: self.len,
+            }),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/foyer-storage/src/device/bytes.rs
+++ b/foyer-storage/src/device/bytes.rs
@@ -421,7 +421,6 @@ impl IoBytes {
     /// Note: The [`IoBytes`] can be a slice of the underlying [`IoBuffer`].
     /// `try_into_io_buffer` always returns the original complete underlying [`IoBuffer`].
     pub fn try_into_io_buffer(self) -> core::result::Result<IoBuffer, Self> {
-        // TODO(MrCroxx): Add `into_io_buffer` with `Arc::into_inner`. See `Arc::try_unwrap` docs.
         match Arc::try_unwrap(self.inner) {
             Ok(inner) => Ok(IoBuffer { inner }),
             Err(inner) => Err(Self {
@@ -430,6 +429,19 @@ impl IoBytes {
                 len: self.len,
             }),
         }
+    }
+
+    /// Returns the underlying buffer as [`IoBuffer`], if the [`IoBytes`] has exactly one reference.
+    ///
+    /// Otherwise, [`None`] is returned.
+    ///
+    /// It is strongly recommended to use `into_io_buffer` instead if you don't want to keep the original [`IoByes`]
+    /// in the [`Err`] path. See `Arc::try_unwrap` and `Arc::into_inner` docs.
+    ///
+    /// Note: The [`IoBytes`] can be a slice of the underlying [`IoBuffer`].
+    /// `try_into_io_buffer` always returns the original complete underlying [`IoBuffer`].
+    pub fn into_io_buffer(self) -> Option<IoBuffer> {
+        Arc::into_inner(self.inner).map(|inner| IoBuffer { inner })
     }
 }
 

--- a/foyer-storage/src/large/batch.rs
+++ b/foyer-storage/src/large/batch.rs
@@ -303,7 +303,6 @@ where
                 groups,
                 tombstones,
                 init,
-                bytes: buffer,
             },
             wait.wait(),
         ))
@@ -443,7 +442,6 @@ where
     pub groups: Vec<Group<K, V, S>>,
     pub tombstones: Vec<TombstoneInfo>,
     pub init: Option<Instant>,
-    pub bytes: IoBytes,
 }
 
 impl<K, V, S> Debug for Batch<K, V, S>

--- a/foyer-storage/src/large/batch.rs
+++ b/foyer-storage/src/large/batch.rs
@@ -244,7 +244,7 @@ where
         }
 
         let buffer = self.buffer_pool.take().unwrap();
-        let mut buffer = buffer.try_into_io_buffer().unwrap();
+        let mut buffer = buffer.into_io_buffer().unwrap();
 
         std::mem::swap(&mut self.buffer, &mut buffer);
         self.len = 0;

--- a/foyer-storage/src/large/flusher.rs
+++ b/foyer-storage/src/large/flusher.rs
@@ -281,6 +281,7 @@ where
             let indexer = self.indexer.clone();
             let region_manager = self.region_manager.clone();
             let stats = self.stats.clone();
+            let flush = self.flush;
             async move {
                 // Wait for region is clean.
                 let region = group.region.handle.await;
@@ -295,7 +296,7 @@ where
                 let size: usize = group.bytes.len();
                 if size > 0 {
                     region.write(group.bytes, group.region.offset).await?;
-                    if self.flush {
+                    if flush {
                         region.flush().await?;
                     }
                     stats.cache_write_bytes.fetch_add(size, Ordering::Relaxed);


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Reduce page fault when writing disk cache io buffer by using a buffer pool with size 1.

This PR will make the call of `BatchMut::rotate` to be much more careful, otherwise there is chance that `BatchMut::rotate` will panic. Maybe refine it with a safer way later.

Comparison: 

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/f8de0078-3e7b-4256-b550-d999cfc46c46">

The page fault is mostly reduced (this blue part). The ratio of total CPU usage for submitting is reduced to 6% from 18%.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #620 