### PR TITLE
feat: support raw block device with DirectFile

### DIFF
--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -142,7 +142,7 @@ jobs:
           CI: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov
-          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench --features "strict_assertions,sanity" -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench --features "strict_assertions,sanity" -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Generate codecov report
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info
@@ -182,7 +182,7 @@ jobs:
         run: |-
           cargo build --all --features deadlock
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage/deadlock
-          timeout 2m ./target/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/deadlock --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          timeout 2m ./target/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/deadlock --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
   asan:
     name: run with address saniziter
     runs-on: ubuntu-latest
@@ -220,7 +220,7 @@ jobs:
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan
-          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Prepare Artifacts on Failure
         if: ${{ failure() }}
         run: |-
@@ -268,7 +268,7 @@ jobs:
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/lsan
-          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/lsan --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/lsan --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Prepare Artifacts on Failure
         if: ${{ failure() }}
         run: |-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
           CI: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov
-          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench --features "strict_assertions,sanity" -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench --features "strict_assertions,sanity" -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Generate codecov report
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info
@@ -188,7 +188,7 @@ jobs:
         run: |-
           cargo build --all --features deadlock
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage/deadlock
-          timeout 2m ./target/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/deadlock --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          timeout 2m ./target/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/deadlock --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
   asan:
     name: run with address saniziter
     runs-on: ubuntu-latest
@@ -226,7 +226,7 @@ jobs:
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan
-          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Prepare Artifacts on Failure
         if: ${{ failure() }}
         run: |-
@@ -274,7 +274,7 @@ jobs:
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/lsan
-          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/lsan --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/lsan --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Prepare Artifacts on Failure
         if: ${{ failure() }}
         run: |-

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -147,7 +147,7 @@ jobs:
           CI: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov
-          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench --features "strict_assertions,sanity" -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          cargo llvm-cov --no-report run --package foyer-bench --bin foyer-bench --features "strict_assertions,sanity" -- --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/codecov --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Generate codecov report
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info
@@ -187,7 +187,7 @@ jobs:
         run: |-
           cargo build --all --features deadlock
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-storage/deadlock
-          timeout 2m ./target/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/deadlock --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          timeout 2m ./target/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/deadlock --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
   asan:
     name: run with address saniziter
     runs-on: ubuntu-latest
@@ -225,7 +225,7 @@ jobs:
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan
-          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Prepare Artifacts on Failure
         if: ${{ failure() }}
         run: |-
@@ -273,7 +273,7 @@ jobs:
         run: |-
           cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/lsan
-          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/lsan --mem 16 --disk 256 --file-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
+          timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/lsan --mem 16 --disk 256 --region-size 16 --get-range 1000 --w-rate 1 --r-rate 1 --admission-rate-limit 10 --time 60
       - name: Prepare Artifacts on Failure
         if: ${{ failure() }}
         run: |-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ metrics = "0.23"
 fastrace = "0.6"
 fastrace-jaeger = "0.6"
 fastrace-opentelemetry = "0.6"
+clap = { version = "4", features = ["derive"] }
 
 [profile.release]
 debug = true

--- a/foyer-bench/Cargo.toml
+++ b/foyer-bench/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 [dependencies]
 anyhow = "1"
 bytesize = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { workspace = true }
 console-subscriber = { version = "0.2", optional = true }
 fastrace = { workspace = true, optional = true }
 fastrace-jaeger = { workspace = true, optional = true }

--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -129,7 +129,7 @@ pub struct Args {
     #[arg(long, default_value_t = 16)]
     readers: usize,
 
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, default_value_t = RecoverMode::None)]
     recover_mode: RecoverMode,
 
     /// Recover concurrency.

--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -18,8 +18,9 @@ mod text;
 
 use bytesize::MIB;
 use foyer::{
-    DirectFsDeviceOptionsBuilder, FifoConfig, FifoPicker, HybridCache, HybridCacheBuilder, InvalidRatioPicker,
-    LfuConfig, LruConfig, RateLimitPicker, RuntimeConfig, S3FifoConfig, TracingConfig,
+    Compression, DirectFileDeviceOptionsBuilder, DirectFsDeviceOptionsBuilder, FifoConfig, FifoPicker, HybridCache,
+    HybridCacheBuilder, InvalidRatioPicker, LfuConfig, LruConfig, RateLimitPicker, RecoverMode, RuntimeConfig,
+    S3FifoConfig, TracingConfig,
 };
 use metrics_exporter_prometheus::PrometheusBuilder;
 
@@ -36,7 +37,7 @@ use std::{
 };
 
 use analyze::{analyze, monitor, Metrics};
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 
 use futures::future::join_all;
 use itertools::Itertools;
@@ -58,10 +59,19 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about)]
+#[command(group = ArgGroup::new("exclusive").required(true).args(&["file", "dir"]))]
 pub struct Args {
-    /// Directory for disk cache data.
+    /// File for disk cache data. Use `DirectFile` as device.
+    ///
+    /// Either `file` or `dir` must be set.
     #[arg(short, long)]
-    dir: String,
+    file: Option<String>,
+
+    /// Directory for disk cache data. Use `DirectFs` as device.
+    ///
+    /// Either `file` or `dir` must be set.
+    #[arg(short, long)]
+    dir: Option<String>,
 
     /// In-memory cache capacity. (MiB)
     #[arg(long, default_value_t = 1024)]
@@ -99,9 +109,9 @@ pub struct Args {
     #[arg(long, default_value_t = 10000)]
     get_range: u64,
 
-    /// Disk cache file size. (MiB)
+    /// Disk cache region size. (MiB)
     #[arg(long, default_value_t = 64)]
-    file_size: usize,
+    region_size: usize,
 
     /// Flusher count.
     #[arg(long, default_value_t = 4)]
@@ -118,6 +128,9 @@ pub struct Args {
     /// Reader count.
     #[arg(long, default_value_t = 16)]
     readers: usize,
+
+    #[arg(long, value_enum)]
+    recover_mode: RecoverMode,
 
     /// Recover concurrency.
     #[arg(long, default_value_t = 16)]
@@ -151,9 +164,9 @@ pub struct Args {
     #[arg(long, default_value_t = 0)]
     max_blocking_threads: usize,
 
-    /// available values: "none", "zstd"
-    #[arg(long, default_value = "none")]
-    compression: String,
+    /// compression algorithm
+    #[arg(long, value_enum, default_value_t = Compression::None)]
+    compression: Compression,
 
     /// Time-series operation distribution.
     ///
@@ -402,8 +415,6 @@ async fn main() {
             .unwrap();
     }
 
-    create_dir_all(&args.dir).unwrap();
-
     let tracing_config = TracingConfig::default();
     tracing_config.set_record_hybrid_insert_threshold(Duration::from_micros(args.trace_insert_us as _));
     tracing_config.set_record_hybrid_get_threshold(Duration::from_micros(args.trace_get_us as _));
@@ -424,15 +435,31 @@ async fn main() {
         _ => panic!("unsupported eviction algorithm: {}", args.eviction),
     };
 
+    if let Some(dir) = args.dir.as_ref() {
+        create_dir_all(dir).unwrap();
+    }
+
     let mut builder = builder
         .with_weighter(|_: &u64, value: &Value| u64::BITS as usize / 8 + value.len())
-        .storage()
-        .with_device_config(
-            DirectFsDeviceOptionsBuilder::new(&args.dir)
+        .storage();
+
+    builder = match (args.file.as_ref(), args.dir.as_ref()) {
+        (Some(file), None) => builder.with_device_config(
+            DirectFileDeviceOptionsBuilder::new(file)
                 .with_capacity(args.disk * MIB as usize)
-                .with_file_size(args.file_size * MIB as usize)
+                .with_region_size(args.region_size * MIB as usize)
                 .build(),
-        )
+        ),
+        (None, Some(dir)) => builder.with_device_config(
+            DirectFsDeviceOptionsBuilder::new(dir)
+                .with_capacity(args.disk * MIB as usize)
+                .with_file_size(args.region_size * MIB as usize)
+                .build(),
+        ),
+        _ => unreachable!(),
+    };
+
+    builder = builder
         .with_flush(args.flush)
         .with_indexer_shards(args.shards)
         .with_recover_concurrency(args.recover_concurrency)
@@ -442,12 +469,7 @@ async fn main() {
             Box::new(InvalidRatioPicker::new(args.invalid_ratio)),
             Box::<FifoPicker>::default(),
         ])
-        .with_compression(
-            args.compression
-                .as_str()
-                .try_into()
-                .expect("unsupported compression algorithm"),
-        )
+        .with_compression(args.compression)
         .with_runtime_config(RuntimeConfig {
             worker_threads: args.runtime_worker_threads,
             max_blocking_threads: args.max_blocking_threads,

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -21,6 +21,7 @@ async-channel = "2"
 bincode = "1"
 bitflags = "2.3.1"
 bytes = "1"
+clap = { workspace = true }
 either = "1"
 fastrace = { workspace = true }
 foyer-common = { version = "0.8.1", path = "../foyer-common" }

--- a/foyer-storage/src/compress.rs
+++ b/foyer-storage/src/compress.rs
@@ -15,11 +15,13 @@
 // TODO(MrCroxx): unify compress interface?
 
 use anyhow::anyhow;
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 
 const NOT_SUPPORT: &str = "compression algorithm not support";
 
 /// The compression algorithm of the disk cache.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 pub enum Compression {
     /// No compression endabled.
     None,
@@ -38,15 +40,6 @@ impl Compression {
             Self::Lz4 => 2,
         }
     }
-
-    /// Get the str that repersent the compression algorithm.
-    pub fn to_str(&self) -> &str {
-        match self {
-            Self::None => "none",
-            Self::Zstd => "zstd",
-            Self::Lz4 => "lz4",
-        }
-    }
 }
 
 impl From<Compression> for u8 {
@@ -55,16 +48,6 @@ impl From<Compression> for u8 {
             Compression::None => 0,
             Compression::Zstd => 1,
             Compression::Lz4 => 2,
-        }
-    }
-}
-
-impl From<Compression> for &str {
-    fn from(value: Compression) -> Self {
-        match value {
-            Compression::None => "none",
-            Compression::Zstd => "zstd",
-            Compression::Lz4 => "lz4",
         }
     }
 }
@@ -79,26 +62,5 @@ impl TryFrom<u8> for Compression {
             2 => Ok(Self::Lz4),
             _ => Err(anyhow!(NOT_SUPPORT)),
         }
-    }
-}
-
-impl TryFrom<&str> for Compression {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "none" => Ok(Self::None),
-            "zstd" => Ok(Self::Zstd),
-            "lz4" => Ok(Self::Lz4),
-            _ => Err(anyhow!(NOT_SUPPORT)),
-        }
-    }
-}
-
-impl TryFrom<String> for Compression {
-    type Error = anyhow::Error;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
     }
 }

--- a/foyer-storage/src/large/recover.rs
+++ b/foyer-storage/src/large/recover.rs
@@ -19,6 +19,7 @@ use std::ops::Range;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use clap::ValueEnum;
 use foyer_common::code::{HashBuilder, StorageKey, StorageValue};
 use futures::future::try_join_all;
 
@@ -43,7 +44,7 @@ use crate::large::tombstone::Tombstone;
 use crate::region::{Region, RegionManager};
 
 /// The recover mode of the disk cache.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 pub enum RecoverMode {
     /// Do not recover disk cache.
     ///

--- a/foyer-storage/src/serde.rs
+++ b/foyer-storage/src/serde.rs
@@ -45,6 +45,7 @@ pub struct EntrySerializer;
 
 impl EntrySerializer {
     #[allow(clippy::needless_borrows_for_generic_args)]
+    #[fastrace::trace(name = "foyer::storage::serde::serialize")]
     pub fn serialize<'a, K, V>(
         key: &'a K,
         value: &'a V,
@@ -92,6 +93,7 @@ impl EntrySerializer {
 pub struct EntryDeserializer;
 
 impl EntryDeserializer {
+    #[fastrace::trace(name = "foyer::storage::serde::deserialize")]
     pub fn deserialize<K, V>(
         buffer: &[u8],
         ken_len: usize,
@@ -122,6 +124,7 @@ impl EntryDeserializer {
         Ok((key, value))
     }
 
+    #[fastrace::trace(name = "foyer::storage::serde::deserialize_key")]
     pub fn deserialize_key<K>(buf: &[u8]) -> Result<K>
     where
         K: StorageKey,
@@ -129,6 +132,7 @@ impl EntryDeserializer {
         bincode::deserialize_from(buf).map_err(Error::from)
     }
 
+    #[fastrace::trace(name = "foyer::storage::serde::deserialize_value")]
     pub fn deserialize_value<V>(buf: &[u8], compression: Compression) -> Result<V>
     where
         V: StorageValue,


### PR DESCRIPTION
Signed-off-by: MrCroxx <mrcroxx@outlook.com>## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Support raw block device directly via `DirectFile`.

And support both clap and serde for `Compression` and `RecoverMode`,

New baseline cmd with raw block device:

```bash
cargo build --release && RUST_LOG=info ./target/release/foyer-bench --file /dev/nvme2n1 --mem 1024 --disk 102400 --region-size 64 --get-range 10000 --flushers 4 --reclaimers 4 --time 30 --writers 256 --w-rate 4 --admission-rate-limit 500 --readers 32 --r-rate 32 --metrics
```

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
